### PR TITLE
Second pull

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+Data/
+
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/notebooks/HMI_data_loading.ipynb
+++ b/notebooks/HMI_data_loading.ipynb
@@ -10,29 +10,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 31,
    "id": "d8f0c730-a507-4288-9331-3295107b57a4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plotting packages\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "\n",
     "import os\n",
     "import natsort  # Sorting package. Used when I parse the folder for files. There may be simpler ways to do this.\n",
-    "import numpy as np\n",
     "\n",
     "import astropy.units as u\n",
     "import astropy.wcs\n",
     "from astropy.coordinates import SkyCoord, SpectralCoord\n",
+    "import datetime\n",
     "\n",
     "import stokespy\n",
     "\n",
+    "import sunpy\n",
+    "from sunpy.net import Fido, attrs\n",
+    "\n",
     "# Set working directory. \n",
-    "# This should be automated.\n",
     "work_dir = os.getcwd()\n",
     "\n",
-    "data_dir = work_dir + '/Data/SDO/'\n",
+    "#data_dir = work_dir + '/Data/SDO/'\n",
+    "data_dir = '/home/gabriel/Desktop/Science/StokesPY' + '/Data/SDO/'\n",
     "\n",
     "script_name = 'HMI_data_loading'\n",
     "\n",
@@ -41,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "bbc0741b-f5e2-446b-9e86-ce430b9f620d",
    "metadata": {},
    "outputs": [
@@ -51,21 +54,25 @@
        "\"\\n# Parse the data folder and select subset of files.\\ninst = 'aia'\\nwave = '171'\\n\\nuse_fnames = parse_folder(dir_path = img_dir, ext='fits', inst='aia', wave='171')\\nprint(len(use_fnames))\\nfor i in use_fnames:\\n    print(i)\\n\""
       ]
      },
-     "execution_count": 4,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "def parse_folder(dir_path=None, inst=None, wave=None, ext=None, \n",
-    "                 series=None, repo='JSOC', show=False):\n",
-    "    '''\n",
+    "                 series=None, repo='JSOC', show=True):\n",
+    "    \"\"\"\n",
     "    Search all the filenames in a folder containing SDO data and use the keywords\n",
     "    to select a desired subset. For example setting inst=\"hmi\" will obtain all the hmi filenames.\n",
+    "    dir_path: Path to the directory containing the data.\n",
     "    inst: SDO instrument\n",
-    "    wave: wavelength (mostly for AIA data)\n",
-    "    ext: limit by file extension\n",
-    "    '''\n",
+    "    wave: wavelength (primarily for AIA data)\n",
+    "    ext: Select the file extension\n",
+    "    series: String characterizing the data series (e.g. hmi.S_720s, aia.lev1_euv_12s)\n",
+    "    repo: Choose the data repository. Each repository stores filenames with different syntaxes.\n",
+    "    show: Flag that enumerates the files found.\n",
+    "    \"\"\"\n",
     "    \n",
     "    if dir_path is None:\n",
     "        dir_path = os.getcwd()\n",
@@ -136,6 +143,169 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 261,
+   "id": "440f8103-0e43-4ab2-b79c-e9b5c4bf44e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_HMI_data(user_date, user_notify='gdima@hawaii.edu', user_dir=None, max_conn=1, download=True, show_files=False):\n",
+    "    \"\"\"\n",
+    "    Function that finds the nearest HMI 720s Stokes data series and inversion results.\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    user_data: `astropy.time` object.\n",
+    "    user_notify: Notification email. This must be registered with JSOC. \n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # Calculate a 1s bounding time around the input date user_date\n",
+    "    # FIDO finds all series where at least one observation was present in the \n",
+    "    # time interval.\n",
+    "    time0 = astropy.time.Time(user_date.gps - 1., format='gps', scale='tai')\n",
+    "    time1 = astropy.time.Time(user_date.gps + 1., format='gps', scale='tai')\n",
+    "\n",
+    "    a_time = attrs.Time(time0, time1)\n",
+    "    print('Time window used for the search: ', a_time)\n",
+    "    \n",
+    "    # Set the notification email. This must be registered with JSOC. \n",
+    "    a_notify = attrs.jsoc.Notify(user_notify)\n",
+    "    \n",
+    "    # Set the default data directory.\n",
+    "    if user_dir is None:\n",
+    "        user_dir = work_dir + '/Data/SDO/'\n",
+    "    \n",
+    "    # Check if the data directory exists and create one if it doesn't.\n",
+    "    if not os.path.exists(user_dir):\n",
+    "        print('Data directory created: ', user_dir)\n",
+    "        os.makedirs(user_dir)\n",
+    "    \n",
+    "    ### Get the 720s HMI Stokes image series ###\n",
+    "    a_series = attrs.jsoc.Series('hmi.S_720s')\n",
+    "    \n",
+    "    if download:\n",
+    "        results_stokes = Fido.search(a_time, a_series, a_notify)\n",
+    "        down_files = Fido.fetch(results_stokes, path=user_dir, max_conn=1)\n",
+    "        # Sort the input names\n",
+    "        all_fnames_stokes = natsort.natsorted(down_files)\n",
+    "    else:\n",
+    "        all_fnames_stokes = parse_folder(dir_path=data_dir, inst='hmi', series='S_720s', ext='fits', show=show_files)\n",
+    "    \n",
+    "        if len(all_fnames_stokes) > 1:\n",
+    "            tstamps = [i.split('.')[2] for i in all_fnames_stokes]\n",
+    "            tstamps = [sunpy.time.parse_time('_'.join(i.split('_')[0:2])) for i in tstamps]\n",
+    "            tstamps_diff = [np.abs(i.gps - user_date.gps) for i in tstamps]\n",
+    "       \n",
+    "            \n",
+    "        # Search for the closest timestamp\n",
+    "        tstamps_diff = np.asarray(tstamps_diff)\n",
+    "        tstamps_ix, = np.where(tstamps_diff == tstamps_diff.min())\n",
+    "\n",
+    "        all_fnames_stokes = np.asarray(all_fnames_stokes)[tstamps_ix]\n",
+    "        \n",
+    "        print(f'No download requested. Nearest {len(all_fnames_stokes)} Stokes files found: ')\n",
+    "        print(all_fnames_stokes)\n",
+    "    \n",
+    "    ### Get the HMI Milne-Eddington magentic field inversion series ###\n",
+    "    a_series = attrs.jsoc.Series('hmi.ME_720s_fd10')\n",
+    "    \n",
+    "    if download:\n",
+    "        results_magvec = Fido.search(a_time, a_series, a_notify)\n",
+    "        down_files = Fido.fetch(results_magvec, path=user_dir, max_conn=1)\n",
+    "        # Sort the input names\n",
+    "        all_fnames_magvec = natsort.natsorted(down_files)\n",
+    "    else:\n",
+    "        all_fnames_magvec = parse_folder(dir_path=data_dir, inst='hmi', series='ME_720s_fd10', ext='fits', show=show_files)\n",
+    "        \n",
+    "        if len(all_fnames_magvec) > 1:\n",
+    "            tstamps = [i.split('.')[2] for i in all_fnames_magvec]\n",
+    "            tstamps = [sunpy.time.parse_time('_'.join(i.split('_')[0:2])) for i in tstamps]\n",
+    "            tstamps_diff = [np.abs(i.gps - user_date.gps) for i in tstamps]\n",
+    "        else:\n",
+    "            print('No files found close to the date requested')\n",
+    "            return \n",
+    "            \n",
+    "        # Search for the closest timestamp\n",
+    "        tstamps_diff = np.asarray(tstamps_diff)\n",
+    "        tstamps_ix, = np.where(tstamps_diff == tstamps_diff.min())\n",
+    "\n",
+    "        all_fnames_magvec = np.asarray(all_fnames_magvec)[tstamps_ix]\n",
+    "        \n",
+    "        print(f'No download requested. Nearest inversion {len(all_fnames_magvec)} files found: ')\n",
+    "        print(all_fnames_magvec)\n",
+    "        \n",
+    "    return all_fnames_stokes, all_fnames_magvec\n",
+    "   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea25da0d-1334-4238-a340-9458be51325a",
+   "metadata": {},
+   "source": [
+    "# Download HMI timeseries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 262,
+   "id": "d2c5ff85-f8fd-4363-aa2a-ecc162c9e65c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time window used for the search:  <sunpy.net.attrs.Time(2016-07-28 23:56:59.000, 2016-07-28 23:57:01.000)>\n",
+      "Export request pending. [id=JSOC_20210602_265, status=2]\n",
+      "Waiting for 0 seconds...\n",
+      "24 URLs found for download. Full request totalling 246MB\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b67d2adacec748baa8db0514ab0d64b2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Files Downloaded:   0%|          | 0/24 [00:00<?, ?file/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Export request pending. [id=JSOC_20210602_353, status=2]\n",
+      "Waiting for 0 seconds...\n",
+      "25 URLs found for download. Full request totalling 307MB\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "849fa4e3dbe64775a7924a1e390d550a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Files Downloaded:   0%|          | 0/25 [00:00<?, ?file/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "user_date = astropy.time.Time(datetime.datetime(2016, 7, 28, 23, 57, 0), scale='tai')\n",
+    "\n",
+    "all_fnames_stokes, all_fnames_magvec = get_HMI_data(user_date, user_notify='gdima@hawaii.edu', download=True)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "d7e7a577-ff90-4c6c-bd9b-d91d29a8afea",
    "metadata": {},
@@ -145,39 +315,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 250,
    "id": "04dff178-9811-4fcf-b770-331b8860bdfa",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.I0.fits\n",
-      "1 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.I1.fits\n",
-      "2 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.I2.fits\n",
-      "3 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.I3.fits\n",
-      "4 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.I4.fits\n",
-      "5 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.I5.fits\n",
-      "6 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.Q0.fits\n",
-      "7 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.Q1.fits\n",
-      "8 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.Q2.fits\n",
-      "9 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.Q3.fits\n",
-      "10 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.Q4.fits\n",
-      "11 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.Q5.fits\n",
-      "12 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.U0.fits\n",
-      "13 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.U1.fits\n",
-      "14 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.U2.fits\n",
-      "15 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.U3.fits\n",
-      "16 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.U4.fits\n",
-      "17 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.U5.fits\n",
-      "18 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.V0.fits\n",
-      "19 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.V1.fits\n",
-      "20 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.V2.fits\n",
-      "21 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.V3.fits\n",
-      "22 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.V4.fits\n",
-      "23 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.s_720s.20160729_000000_TAI.3.V5.fits\n"
-     ]
+     "data": {
+      "text/plain": [
+       "array(['/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.I0.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.I1.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.I2.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.I3.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.I4.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.I5.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.Q0.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.Q1.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.Q2.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.Q3.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.Q4.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.Q5.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.U0.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.U1.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.U2.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.U3.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.U4.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.U5.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.V0.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.V1.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.V2.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.V3.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.V4.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.s_720s.20160728_234800_TAI.3.V5.fits'],\n",
+       "      dtype='<U88')"
+      ]
+     },
+     "execution_count": 250,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -186,7 +360,9 @@
     "# and type of series wanted. \n",
     "# Stokes series is labeled with: S_720s\n",
     "\n",
-    "all_fnames= parse_folder(dir_path=data_dir, inst='hmi', series='S_720s', ext='fits', show=True)"
+    "#all_fnames= parse_folder(dir_path=data_dir, inst='hmi', series='S_720s', ext='fits', show=True)\n",
+    "all_fnames = all_fnames_stokes\n",
+    "all_fnames"
    ]
   },
   {
@@ -199,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 251,
    "id": "ba3c209f-1a59-4159-9305-23bf63f067f0",
    "metadata": {},
    "outputs": [
@@ -238,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 252,
    "id": "84870c31-79f4-4813-8a22-c2f3acc31114",
    "metadata": {},
    "outputs": [],
@@ -272,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 253,
    "id": "fdffd828-367f-45db-bf7c-f0c0e52d0b70",
    "metadata": {},
    "outputs": [
@@ -284,16 +460,16 @@
        "Number of WCS axes: 4\n",
        "CTYPE : 'HPLN-TAN'  'HPLT-TAN'  'WAVE'  'STOKES'  \n",
        "CRVAL : 0.0  0.0  6.173345e-07  0.0  \n",
-       "CRPIX : 2039.1423339844  2051.4689941406  3.5  0.0  \n",
-       "PC1_1 PC1_2 PC1_3 PC1_4  : -0.99999997203655  0.00023648870259451  0.0  0.0  \n",
-       "PC2_1 PC2_2 PC2_3 PC2_4  : -0.00023648870259451  -0.99999997203655  0.0  0.0  \n",
+       "CRPIX : 2039.1322021484  2051.4501953125  3.5  0.0  \n",
+       "PC1_1 PC1_2 PC1_3 PC1_4  : -0.99999997184728  0.00023728765089914  0.0  0.0  \n",
+       "PC2_1 PC2_2 PC2_3 PC2_4  : -0.00023728765089914  -0.99999997184728  0.0  0.0  \n",
        "PC3_1 PC3_2 PC3_3 PC3_4  : 0.0  0.0  1.0  0.0  \n",
        "PC4_1 PC4_2 PC4_3 PC4_4  : 0.0  0.0  0.0  1.0  \n",
-       "CDELT : 0.00014009369744195  0.00014009369744195  6.88e-12  1.0  \n",
+       "CDELT : 0.00014009374711249  0.00014009374711249  6.88e-12  1.0  \n",
        "NAXIS : 0  0"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 253,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -304,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 145,
    "id": "3eab1e3d-466d-4272-9d92-162059ebcf5b",
    "metadata": {},
    "outputs": [
@@ -314,7 +490,7 @@
        "['deg', 'deg', 'm', '']"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 145,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -333,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 254,
    "id": "e1adaccd-41d6-4869-b0e9-c5552c43dea4",
    "metadata": {},
    "outputs": [],
@@ -343,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 255,
    "id": "c115fd91-f33c-4049-8293-4a8f13229f46",
    "metadata": {},
    "outputs": [
@@ -378,40 +554,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 256,
    "id": "6d189685-e619-4141-9ec8-39c3ea68d6a4",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.alpha_err.fits\n",
-      "1 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.alpha_mag.fits\n",
-      "2 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.azimuth.fits\n",
-      "3 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.azimuth_alpha_err.fits\n",
-      "4 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.azimuth_err.fits\n",
-      "5 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.chisq.fits\n",
-      "6 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.confid_map.fits\n",
-      "7 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.conv_flag.fits\n",
-      "8 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.damping.fits\n",
-      "9 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.dop_width.fits\n",
-      "10 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.eta_0.fits\n",
-      "11 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.field.fits\n",
-      "12 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.field_alpha_err.fits\n",
-      "13 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.field_az_err.fits\n",
-      "14 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.field_err.fits\n",
-      "15 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.field_inclination_err.fits\n",
-      "16 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.inclin_azimuth_err.fits\n",
-      "17 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.inclination.fits\n",
-      "18 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.inclination_alpha_err.fits\n",
-      "19 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.inclination_err.fits\n",
-      "20 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.qual_map.fits\n",
-      "21 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.src_continuum.fits\n",
-      "22 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.src_grad.fits\n",
-      "23 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.vlos_err.fits\n",
-      "24 /home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.vlos_mag.fits\n"
-     ]
+     "data": {
+      "text/plain": [
+       "array(['/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.alpha_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.alpha_mag.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.azimuth.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.azimuth_alpha_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.azimuth_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.chisq.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.confid_map.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.conv_flag.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.damping.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.dop_width.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.eta_0.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.field.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.field_alpha_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.field_az_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.field_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.field_inclination_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.inclin_azimuth_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.inclination.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.inclination_alpha_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.inclination_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.qual_map.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.src_continuum.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.src_grad.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.vlos_err.fits',\n",
+       "       '/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.vlos_mag.fits'],\n",
+       "      dtype='<U111')"
+      ]
+     },
+     "execution_count": 256,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -420,7 +600,10 @@
     "# and type of series wanted. \n",
     "# Stokes series is labeled with: S_720s\n",
     "\n",
-    "all_fnames = parse_folder(dir_path=data_dir, inst='hmi', series='me_720s_fd10', ext='fits', show=True)"
+    "#all_fnames = parse_folder(dir_path=data_dir, inst='hmi', series='me_720s_fd10', ext='fits', show=True)\n",
+    "\n",
+    "all_fnames = all_fnames_magvec\n",
+    "all_fnames"
    ]
   },
   {
@@ -433,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 257,
    "id": "7dc65b1b-d9ff-48ca-9875-94562b45d767",
    "metadata": {},
    "outputs": [
@@ -443,9 +626,9 @@
      "text": [
       "Created data cube with dimensions: (3, 4096, 4096)\n",
       "Filenames used: \n",
-      "/home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.field.fits\n",
-      "/home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.inclination.fits\n",
-      "/home/gabriel/Desktop/Science/StokesPY/stokespy/notebooks/Data/SDO/hmi.me_720s_fd10.20160729_000000_TAI.azimuth.fits\n"
+      "/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.field.fits\n",
+      "/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.inclination.fits\n",
+      "/home/gabriel/Desktop/Science/StokesPY/Data/SDO/hmi.me_720s_fd10.20160728_234800_TAI.azimuth.fits\n"
      ]
     }
    ],
@@ -456,7 +639,7 @@
     "wcs_obj = []\n",
     "header_info = []\n",
     "\n",
-    "# Load the data in the order determined y\n",
+    "# Load 2D maps into level2_data in the order determined by entries in mag_params\n",
     "use_fnames = []\n",
     "for mag_param in mag_params:\n",
     "    for i, fname in enumerate(all_fnames):\n",
@@ -467,9 +650,9 @@
     "                level2_data.append(hdulist[1].data)\n",
     "                wcs_obj.append(astropy.wcs.WCS(hdulist[1].header))\n",
     "                header_info.append(hdulist[1].header)\n",
-    "            \n",
+    "\n",
     "level2_data = np.asarray(level2_data)\n",
-    "            \n",
+    "                \n",
     "print(f'Created data cube with dimensions: {level2_data.shape}')\n",
     "print('Filenames used: ')\n",
     "for fname in use_fnames:\n",
@@ -486,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 258,
    "id": "1320b0bf-68ef-4491-a81c-fbfbe24b4554",
    "metadata": {},
    "outputs": [],
@@ -498,7 +681,7 @@
     "\n",
     "wcs_header[\"WCSAXES\"] = 3\n",
     "\n",
-    "# Add Stokes axis.\n",
+    "# Add Magnetic field axis.\n",
     "wcs_header[\"CRPIX3\"] = 0\n",
     "wcs_header[\"CDELT3\"] = 1\n",
     "wcs_header[\"CUNIT3\"] = ''\n",
@@ -518,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 259,
    "id": "dcd1b5c1-4cd6-4831-aac2-6286d2dc0d44",
    "metadata": {},
    "outputs": [],
@@ -528,14 +711,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 260,
    "id": "f5d95ce9-6ba5-44aa-8bf3-0c57baf4eeca",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a88340737959479bb487bb477c08f14b",
+       "model_id": "add5810c677847bc98a9e2b126f2d536",
        "version_major": 2,
        "version_minor": 0
       },
@@ -552,7 +735,7 @@
        "<WCSAxesSubplot:>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 260,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -562,14 +745,14 @@
     "#%matplotlib notebook\n",
     "%matplotlib widget  \n",
     "\n",
-    "mag_map = level2_cube.B_map\n",
+    "mag_map = level2_cube.B\n",
     "mag_map.plot()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f8cbb99-b5b9-4660-8409-ae19c6d63201",
+   "id": "d69fcef1-8c00-42c6-8741-5a60536920c9",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -591,23 +774,6786 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "31d4694f7fb24631a56b992acf349b5f": {
+     "004a5dfaffdc4a4db92fd53dfea4bfad": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "5cd3d9e4fcbe4c809740f6e68c088891": {
+     "005f1830b8ef41e6bf03a7be86d395d2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "006dc40de7b14a91b186f0645810e5a0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "009bf82fcddb4c80b25ea987dc48a2f9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "00a14d654dd74e31b0a24dc3aabc12a3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1cd172b0a5b4435486f688b5a3df1e03",
+       "style": "IPY_MODEL_6e1b195b77a1455e91630496cd94951e",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "00af31a121094ad392d2e95a24d8b15d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "00bbb102498548b4bb54af989a33df9d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c7a06b03efaa4342860a7eb10b92e140",
+       "style": "IPY_MODEL_3855465dd9114c36ae2e454025c2c46b",
+       "value": " 15.3M/? [00:16&lt;00:00, 9.48MB/s]"
+      }
+     },
+     "00d0918a517d4b94b67faaf5aa1cd7b0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_17152ef9458b40b9920afd14f6b494bc",
+       "style": "IPY_MODEL_b42ea14fc95b46fda310f79db7e41b86",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.chisq.fits: "
+      }
+     },
+     "010b38ff757b4de392ad6b0515896568": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "011d24cd26d64feba2efa30e975b7d0e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8e22eb3cec774bd99b50d500c2a58ae8",
+       "style": "IPY_MODEL_7cce927de83046c5a3d72467aac0690c",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.vlos_mag.fits: "
+      }
+     },
+     "013114be289e4d10941a160b5878f7f9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "013dcf36ceca4d4f9e90c8984daa976d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "013f7f07fe694d06a8c1d0d7393e8a39": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "014cb3b16da94081b3a23d095b0acbe4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "01537159d4a64d2db0b9c5cb222e59a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bdb24d1f922849d593e1f91d94b2bdf9",
+       "style": "IPY_MODEL_a974e4ca8df74ef08e745345447c4ed6",
+       "value": " 7.98M/? [00:12&lt;00:00, 4.99MB/s]"
+      }
+     },
+     "01ab36817c274f8884de97303c1327be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "01e39607191541dbb384da1082329d4a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "01eb22de4bd34c3fa21ed2a067e004d2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "02421d49f8f1467da076032367c6ae2b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_263076f020ec4ef88395ac0aef86eeba",
+       "max": 25,
+       "style": "IPY_MODEL_724ab035499b4bbdb7b264ebd6fb29d8",
+       "value": 25
+      }
+     },
+     "024d596a440d4083a85cd92e93f4dda8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "02eca571cd284f80affbfa050b7067e6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "033e523f8e63405f88585dc216d78f87": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0341480858ae4824bd892b5d71b80c84": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e35554a7de11468abbf75e8b6d2e2ed3",
+       "max": 9711360,
+       "style": "IPY_MODEL_a6cb0276deaf43a5b29ebe091465b708",
+       "value": 9711360
+      }
+     },
+     "03521c084fcf408bbcc492470d7a8adb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_e8f0d6f2a60e4c7fad48923c5ef0dd50",
+       "max": 25,
+       "style": "IPY_MODEL_13494b12157544a491ff282c9e08e588",
+       "value": 25
+      }
+     },
+     "03692eb366c640c6962d74a163ff5d7b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "03869cf8621241c88edd1c652b5453d4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_fdc17c21fa4543e7a0d69008e6e0928f",
+        "IPY_MODEL_433534285fa94e5593b151deecdd4436",
+        "IPY_MODEL_faa550e4276a408b840a440843e9d5a4"
+       ],
+       "layout": "IPY_MODEL_7fbf50ac3aa141dfbce5ce008b7efe1e"
+      }
+     },
+     "03a0a69df8e84c88b9ac0146153010e7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "03c55e1fb54d4a81a4a56ff7eaf9cb9b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "041c06821d134566ac178d4146f1044e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_1f589064c35a40d2b14f26df19c12b4b",
+        "IPY_MODEL_2a833cabc224468a9bfa4d40df6eef84",
+        "IPY_MODEL_303193aa449342889f6f15919b53bcbb"
+       ],
+       "layout": "IPY_MODEL_d6f4d44e16bd43fca98bcca0c5027ce3"
+      }
+     },
+     "043eb95d6a1b440ca0ab5fb01ea5844d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c74ddc0486fc46f98e12e930697ce203",
+       "style": "IPY_MODEL_ce047f67f3ed43719a4499579813d3b3",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field_inclination_err.fits: "
+      }
+     },
+     "0463a83eb1714487b2a001586ba6b174": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "04bc20f0356e4923a006b5fe7389eacb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5c76906109af463d9c47845fd0eef111",
+       "style": "IPY_MODEL_82ba988aa92c4e3aac2dc4685e82dfd2",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.src_continuum.fits: "
+      }
+     },
+     "04d1ecece69b43d686bcddf2f8a4f5b8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_528d7956ed644e0abac6023c19eb0ca4",
+       "style": "IPY_MODEL_dd43021bf7d34bb08d967d38add29951",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I2.fits: "
+      }
+     },
+     "04db521baf4d4cb2b9cf0e2d18c7d518": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9edd891ea3d04469ae31d361f5c52a5c",
+       "style": "IPY_MODEL_287ad18d2a8e4aa5881f47b2b1bc8687",
+       "value": " 9.20M/? [00:17&lt;00:00, 7.15MB/s]"
+      }
+     },
+     "04f0fd8b8dbc449e8de35892c07efd14": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0509964683814e0783684642660e8e5f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_48a170bf4d0b40aa8f9197da3b1e3d99",
+       "max": 9731520,
+       "style": "IPY_MODEL_b3e8269d75804127bf2c25d26afa0343",
+       "value": 9731520
+      }
+     },
+     "051065ce87de478aa89a73eebafe5e7d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b97f582da759462badf0c47c964353f8",
+       "style": "IPY_MODEL_6bf8b6a02ec8444aaa9779114c92b1e3",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.dop_width.fits: "
+      }
+     },
+     "0510808fecf14cd688aa92166764aa30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "059a49ae9b25457db8a35a0245760a1b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_892920d09d4c41f6abc9c2c90419614a",
+       "max": 20450880,
+       "style": "IPY_MODEL_158ec871baa04cda97d5023f1f80d132",
+       "value": 20450880
+      }
+     },
+     "05af202bf9cb400b8d2351779caa2701": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_59de1052fcce4fa5b3675b9b1d2a48e7",
+       "style": "IPY_MODEL_f3ebbfa3711345e19650a0e78678786c",
+       "value": " 9.70M/? [00:16&lt;00:00, 7.38MB/s]"
+      }
+     },
+     "05ce757b91e04510984183439ce06439": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "05fc4030600046cdaf2f91e409aee81c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0603eba9be524859bbcee2e6fd43e45f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "060dd493513c45328abd494f8de30f47": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0643e86c7440435fa792c0e5ec7c1bb0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "06563c6aed64481abfeb2b2b6745fe36": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "068ac3f4a84346c5b551a4c4852e1ccc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e7e51dfc6d0745efb9f781ed2cd3cf2b",
+       "style": "IPY_MODEL_45e6b7a7c65b41d392a7b15f5cafe725",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "0697177b408d410082793d9856e98df4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_34c8eebe166b4fd79c729b65265e44af",
+       "style": "IPY_MODEL_e248e49c77e34813a0b9eed3e7d91bfd",
+       "value": " 395k/? [00:18&lt;00:00, 778kB/s]"
+      }
+     },
+     "06ecfadf2ca94043ab603eed7fd16529": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fee37904714340cbb5fc45188f95abc3",
+       "style": "IPY_MODEL_6b30edd5e66847bda93d0e76128f8f8f",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.I3.fits: "
+      }
+     },
+     "0706f1be0acc4e24a533970ea1294f65": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1208a14be605407f887885bc38ce348d",
+       "style": "IPY_MODEL_8b3bc79da85d4bae8bbdca1c6c77ecb6",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.src_continuum.fits: "
+      }
+     },
+     "076ac9f53dfd4e1db5c07f024599dd0d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0778870ccae144c9bb789214d620a2b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e7bbb674094b42f7bbdff8ca9d79bc57",
+       "style": "IPY_MODEL_e1021c0886cc4292886f3f4522b8197a",
+       "value": " 14.7M/? [00:17&lt;00:00, 6.56MB/s]"
+      }
+     },
+     "079820ca51aa4287bd8f6a9807aade30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "07f5bf50115b4411b33b0d91ca5205fb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "07fac29b68894d128ecd476530cf9c0f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "081bf65d682e4f2f84e39553d5eb9401": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8c542ccf656a48868a40ca33d275d8eb",
+       "max": 8683200,
+       "style": "IPY_MODEL_9ec4ff5b4c164afab9a68d35cf6e86c1",
+       "value": 8683200
+      }
+     },
+     "088441fd2a8f42c081cc9cee8545129e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_9b37358837db4e0fbfa5aa507d3ab262",
+        "IPY_MODEL_46238d5080074debbebf2563a62b629f",
+        "IPY_MODEL_e9dd13dfa3db45b3a6bf83879c8fe8d1"
+       ],
+       "layout": "IPY_MODEL_7b45b9c03ac44ae09a636056dc7eb65d"
+      }
+     },
+     "08b8f81d8b3346df981ec6ba9087e053": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "08c82b67428b413ba07547d5be31bc74": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "08ce049310d14d32823094a7b9df46e7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_63ed1eab46b84d368286c581aca93b0c",
+        "IPY_MODEL_cd82ea41bf2245ec9e183f0533ee5839",
+        "IPY_MODEL_1abb4acef16b431b934a89c4f0e4d44d"
+       ],
+       "layout": "IPY_MODEL_b409b5ffb9e44a769b69b151f699c064"
+      }
+     },
+     "08fa9fe929e24474bf0d97ea9d3af20b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "08feed14d3f04e6cb0a75f9645f5732c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0901e43f51e84dd8bbb3dfc6aa02f174": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "090f30b5c36b4cdb88c430fdcc1a950c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c88ebb6e3787421187cf87aff6236307",
+        "IPY_MODEL_a3c328754ab44efea564ec7dc7379f6a",
+        "IPY_MODEL_9ff857a666d3480a90b015eb77d343fb"
+       ],
+       "layout": "IPY_MODEL_78015fbdc07a4d82b56a8d0b0fc3714d"
+      }
+     },
+     "0931018cf6cd4beda41e5651d1d54889": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bbbdce95e9254130a72d45f52677d4b6",
+       "style": "IPY_MODEL_33dcc82fc4ca4855a80bdac875fdc580",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q1.fits: "
+      }
+     },
+     "0953d02838fd4f07b3af9f30462043eb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_0931018cf6cd4beda41e5651d1d54889",
+        "IPY_MODEL_ed59d8e5bde94ef093430f3f7d271fa7",
+        "IPY_MODEL_b7bf027eed94407a86aae51518377d0f"
+       ],
+       "layout": "IPY_MODEL_9bfb88c014c744898efd83a2c4624bb9"
+      }
+     },
+     "096ad4532a944c73986a4bfe5124becf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_013f7f07fe694d06a8c1d0d7393e8a39",
+       "max": 24,
+       "style": "IPY_MODEL_9b937d9648ae40cc8627b5e0ac5b6909",
+       "value": 24
+      }
+     },
+     "097c7ae27cf64968b8f34d5e0febd3f2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a60fed1f50924f5ca9b712a8e48aea6d",
+        "IPY_MODEL_809feafb33bc4485a96795b3156a65a4",
+        "IPY_MODEL_0f761983e2a24798a36a0ae821dde917"
+       ],
+       "layout": "IPY_MODEL_7522fe90cdfd4f75bd2af6c105153e5d"
+      }
+     },
+     "097cbb94ead24691a7b7c3e5db12e6fb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "09d450425ff5489b9a38f8e12453e71c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_bc14e3b9e2804f66842ada2805016cf7",
+       "max": 25,
+       "style": "IPY_MODEL_00af31a121094ad392d2e95a24d8b15d",
+       "value": 25
+      }
+     },
+     "09f79a734fa74c45985c003030deae25": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5bd25dc5cdec4c70836fa0e905e6ed53",
+       "style": "IPY_MODEL_52443da88f63435eb1f1bfcfbcff962f",
+       "value": " 21.7M/? [00:24&lt;00:00, 7.32MB/s]"
+      }
+     },
+     "0a50c5b7b98c485bb5ebb2764ed93bf1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0a5e1be9c4354d5eb992ca548fc98e14": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7f033808831746e0a16e07b577c19c24",
+       "style": "IPY_MODEL_f9a3ea3527914121ad1ad0e63c64a38c",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.azimuth_err.fits: "
+      }
+     },
+     "0a8f2343bb9e4f65b7110067b57d2b5c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0aaa65c71b924998a0fe4ab46538ae02": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0aad326e75ff42bcb707d2f4743f89f5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0ab1ae647fc6426982e3ba6daf5099f7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_2688713e31244f7cb6ddec2974e8e6f4",
+        "IPY_MODEL_793e41db359247699563aabfd9404396",
+        "IPY_MODEL_49a47110a4bf44c5b94bf2847409701a"
+       ],
+       "layout": "IPY_MODEL_2a6ae473b63c49ae8eca1c3cb1415a89"
+      }
+     },
+     "0aba60ccacbc4b9aa2fdcab9310b93ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0b0ef505e69c4da7847239cda158b436": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0b5c01826aa34133a8835793e96c6094": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0b6aa4323a9a4fe494bdcc24bddc597c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0b6f2de314c34ee5866679608ae76d98": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_fe583b8d61ab4799ae5883fe6b35a600",
+       "max": 9336960,
+       "style": "IPY_MODEL_b1998b669cf34c138f37dc258e9f1173",
+       "value": 9336960
+      }
+     },
+     "0bac7882736643dea22fddf4eb2caef2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0bb6814116944d0daf9b3cfdf9499a62": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0bc87388af5b4420b1a04f862c525c41": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0bcf902ee988452ca632e6326ddb9321": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0c9aac6f7d53436fb7986e19b2b65ddd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0cd797abbee140988d56989919c562d8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0ce8fea7f31f4a44a674824c7763b015": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0d0c81a16de249cd9121662ddf13b82a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0d215daa697e47218aff55c371a7a53c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_96655b99879a462182910acf00948690",
+        "IPY_MODEL_58d80fef179d4ecfbb77246664cca4ab",
+        "IPY_MODEL_2f53aceb1a1747ada086753f35d90a31"
+       ],
+       "layout": "IPY_MODEL_4a66192a1e7a41d9b00fabdd0a18f1bd"
+      }
+     },
+     "0d48590e47e04fe38ea4f98e92ca5c94": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0d528bcc9652403a947debd2591d767d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0d558a98d11d43d5ac6ab0ca876f7737": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0d55e2d8ec4d4c88b4f5407592b4a315": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_cca2ba193148406988a70188de67ad88",
+       "max": 50,
+       "style": "IPY_MODEL_e260e3e434b54c0999410ce77a0b6305",
+       "value": 50
+      }
+     },
+     "0d77e5fd10614d1c9b462facd168e97d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0da833ab931f42349a05e0ae6b7c0abc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0dbcfb6575ea4bceb2a4713f88105f4a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0dd2c8bdee114cf3bd5c78482ff673d1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0dda9dc241634835bb9fa9b8b1100e21": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0ddce2d309ea43afafd7733dd948ea61": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_bdfd9d1f4c434318b0569e103f0f5397",
+       "max": 25,
+       "style": "IPY_MODEL_724b2abe4b4a4b3690aa83ce95705a75",
+       "value": 25
+      }
+     },
+     "0e0769edbf604a67a7f093d99d5eb696": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0e484172246645b1aa0ecf6ce6695700": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0e68aeb970cc43b1af9778004177ad0e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0e6ce4ad942648c9bce24331e2cffa08": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0e7d82347c4649bbbcfb90a9087b8785": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5bba8fc24aa34853a74eab344e7f7c75",
+        "IPY_MODEL_423dabad19414ad2bf8f1517dfc10201",
+        "IPY_MODEL_66bf071007cb4826b84767c98269c769"
+       ],
+       "layout": "IPY_MODEL_03a0a69df8e84c88b9ac0146153010e7"
+      }
+     },
+     "0e944d824cde4e92a9934a230b63dab7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0f5e5d652d1a489b8c5d1f466e3c08fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_40275b8e48ba4f4f8801efe01667d066",
+       "style": "IPY_MODEL_a62b46f2e5414ba889098dfc01910db7",
+       "value": " 19.2M/? [00:24&lt;00:00, 5.23MB/s]"
+      }
+     },
+     "0f70e1f1a87d4925afcd739c329e6193": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0f761983e2a24798a36a0ae821dde917": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1065fcce0cd44c3ba9b4ef821465873f",
+       "style": "IPY_MODEL_f64cde2118a9484a9e34b05933f93069",
+       "value": " 9.71M/? [00:19&lt;00:00, 7.20MB/s]"
+      }
+     },
+     "0fcbddc8f07941139840873899f14a25": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0fd0ca8ef88444ff89870ee791664c3e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0ff978567d9746e2923c3acbb370ce16": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_07f5bf50115b4411b33b0d91ca5205fb",
+       "style": "IPY_MODEL_c4fc0d15e12c47d4b4b890c8710d9396",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U5.fits: "
+      }
+     },
+     "0ff9f991007942139036a197b87d696d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4ca861e6cf2d4f47b42090d26e7aa0a2",
+       "style": "IPY_MODEL_a2d431f97a344997ada0cf13cd9298f5",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.azimuth_alpha_err.fits: "
+      }
+     },
+     "0ffc6ee658c6417ab6cc583525af82c3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "100e46f20af04acf96fd6efdae94c6eb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "101734ba2e5b4860a501f45a5e880ba0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4936eeb40b934321aaf818ae7b270918",
+        "IPY_MODEL_1ff4ee4ce6874ff58383431f56af63a8",
+        "IPY_MODEL_f75673f3ee574de2a0b47faf7b8b4d41"
+       ],
+       "layout": "IPY_MODEL_b12a346beb014586bf604f9ec674803f"
+      }
+     },
+     "1036b59b8eca4a2c8c56b8dac7359b34": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "103ffb55a90745e691e95d922ec3c1a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e1e0fc57ca1744cc886a364f33a4362d",
+       "max": 9573120,
+       "style": "IPY_MODEL_6472a0d99d9d4e81b8c25f1da338c251",
+       "value": 9573120
+      }
+     },
+     "1056c8fc12ac40bfa8121a15431cf789": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "10595644328a418096ad1efb7831a72e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1065fcce0cd44c3ba9b4ef821465873f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "106f9ce01ee04a328bc1a0aef92555cb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "109d724c1e6941348594cb39dacd8397": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d80614d16a994f5fbb9be99d363d4eb3",
+       "style": "IPY_MODEL_e42710b83bd64f2c9e6fe3ad99b0f353",
+       "value": " 7.96M/? [00:13&lt;00:00, 5.70MB/s]"
+      }
+     },
+     "10a7fb8a47844918b3dbacf2d4c6a6f8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5aa7e14a7e824ca68fa161de0cb117e5",
+       "style": "IPY_MODEL_75f1329fb71e4f9d9cc380dfca0fb935",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.inclin_azimuth_err.fits: "
+      }
+     },
+     "10ae22cbbad84951b576c68d5615d6c1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_def0f690ef2b40db9739882e30430091",
+       "style": "IPY_MODEL_57c3b03ad76e440fbb5f472969ae05dc",
+       "value": " 21.8M/? [00:16&lt;00:00, 6.34MB/s]"
+      }
+     },
+     "10c5092ed67a41ff8064a1d0a55699c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "10d20db4d5424ebfa46916342fe94890": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "10e0e015267e4f609edfa6e63c6ace15": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "10e1a6b1aaf44307a58b49f0066eee81": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "10f506c03ad746be8e3f02afae13dcf5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1100c0c83d034fb0a4f470663e110b4f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f1c09988b44043bc8521d63f5a7f5c02",
+       "style": "IPY_MODEL_d48a0649b4d0472aba2e01cff8c44188",
+       "value": " 2.90M/? [00:17&lt;00:00, 2.50MB/s]"
+      }
+     },
+     "11376b334fbe459a9d4e5d8fb5b6c92b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_16129b9ec1a24340a0f7a4c91c688595",
+        "IPY_MODEL_88ac13870ed34f0cbe71e0e4545a3597",
+        "IPY_MODEL_7bce329f6e904c9596fa8f973a1c6d41"
+       ],
+       "layout": "IPY_MODEL_d537959166034f7ea8de69c3ce58988f"
+      }
+     },
+     "113872d9cf56436280de63b000f8ace0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "113872e8dce84631b933b37bb34436c2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "11638f553bb04f0e82f9c4e49c67f0ef": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bd6faffd34c54287a63f3edaf24d8087",
+       "style": "IPY_MODEL_328e598e9e304612bcfa87fc53b0162b",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.field.fits: "
+      }
+     },
+     "117ae5b31e314abe80551993b85e0c02": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b804d8f2577747778f680cc4e2fcfbb0",
+       "style": "IPY_MODEL_b7266ae7775c46879ab35453fc52423e",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.src_grad.fits: "
+      }
+     },
+     "11a234b7c25542228be6fc5a4998ef6a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_54bc6ee425be4ed781e800d76d4568dc",
+       "style": "IPY_MODEL_a045f889d5c8434b865326ed48a9d92e",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "11b88e525d9444c493bb0c2cfb492d60": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a6ab216562984612aaed99d04b18845b",
+        "IPY_MODEL_27a3cf525d0b4dbcbff2ca842e76e1e7",
+        "IPY_MODEL_e9c9c7683cfa4c91a3dc7e5e54f85e11"
+       ],
+       "layout": "IPY_MODEL_5da5a6c0ff43423b9fc579cfe4c31959"
+      }
+     },
+     "11b90cc60851429b8cab000cbe64f856": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_94276fc69e21487c901eddb23a5a0da0",
+       "style": "IPY_MODEL_51b428845713473393e15d20af79b314",
+       "value": " 8.73M/? [00:21&lt;00:00, 6.90MB/s]"
+      }
+     },
+     "11e5e05ca86146a7adef2ffa3a254f19": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1208a14be605407f887885bc38ce348d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "12243ee759bf4dbab39e1b49e44d9651": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7e9068e1b86b4142b0b68ad1cf2aa98c",
+       "style": "IPY_MODEL_a600d833951a457590dc6bb8742c3876",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q3.fits: "
+      }
+     },
+     "1240354c16f74fbda560cbb9049b248b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "125bd89b2d0942658e48a2a7851eb45a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "12c655f93943482dba7429623bdff0df": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5d826d34eec14d0994b6bb0ab855251a",
+       "style": "IPY_MODEL_a888fbeb87414258b464a5afe43a713e",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "12f9aa81c2834c9297b307958fbd858b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6aea4578c4a2453684b58802fe7663ab",
+        "IPY_MODEL_7f888f244b3047a3b169fa6873009d99",
+        "IPY_MODEL_4a5ee02bac984a6087c1ae0194fe4c48"
+       ],
+       "layout": "IPY_MODEL_9300631a8750491b9a078ee6286e72e7"
+      }
+     },
+     "13277c907c6d4a68af5fce735103e8d1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_42a004c78cb14eb6ab5fb18b7eeb4f03",
+       "max": 15537600,
+       "style": "IPY_MODEL_d064242f178c498ba07b9389d7e31de3",
+       "value": 15537600
+      }
+     },
+     "13494b12157544a491ff282c9e08e588": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1354b41bec3b408690514d004265e221": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "136a5f65dd0749418e739a7ad37839b3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3bf7469f0dea4a728cb48a261e56ae45",
+       "style": "IPY_MODEL_6c925084b55641deb723456de8ee666c",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "13751b6c522f4008ae50cb4aa5127b92": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_71faae84ad71461dab717cda40540a32",
+       "style": "IPY_MODEL_0e944d824cde4e92a9934a230b63dab7",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field.fits: "
+      }
+     },
+     "137e664e7e2149d4ba870fb4fba64563": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "139292607cc8415da0c9385a7dad7523": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "13955c754d1e4ee88c0692d7cf7d941f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c0421924b1c944d8bd01383200528bb4",
+        "IPY_MODEL_960f36aeac704d25afa55174d0fd1b70",
+        "IPY_MODEL_86d4d866ccd14dfba37958dea12e22a9"
+       ],
+       "layout": "IPY_MODEL_6af10cfa36b848eaaeb60a137dd109b1"
+      }
+     },
+     "13b6f0e4556d4be2b23d6c82b81d3a83": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2e65151401d742068ffff25fc409799b",
+       "style": "IPY_MODEL_a3d175ce4db54a6e9d8fede486e09de3",
+       "value": " 9.33M/? [00:16&lt;00:00, 7.23MB/s]"
+      }
+     },
+     "145eeb97e9634300be6a7a720ada4470": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "14711b31264246b6ac419b17a674f675": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "147c5fd132d648448d23b98890b35ecc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4247b8760c814e4ab2f61f3239f8305f",
+       "style": "IPY_MODEL_cb0c0eb05e4f4cf5a7e7d2e7edb5a63c",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.U1.fits: "
+      }
+     },
+     "14cbf02706cc4f258b00d11d53fe05ab": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "14ce98576c5a4c2aa68aa32feff1f7bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "14f5f56915a346ad89ac03d0aaf90f39": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d188c8eeca7b40e1878b08912779863f",
+       "style": "IPY_MODEL_a1496dcbf1dc41aa8d70624df7c1eada",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.V5.fits: "
+      }
+     },
+     "150888badc744bdda52291237f1750c0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "15312e9950d64fe191ef3bf87c4e03c2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1561e43c32274a1e8ad53a8d4eeb127f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1574b981660948f7bfd8c13faa0b3ac4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "158ec871baa04cda97d5023f1f80d132": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1590a40751d645adb8a0a2f58bc2f4b0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "15a247bf8eb14eeeb37d7be75236474f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "15b4c68bd4214765ae29b2394c78852b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4ee85e9f209240fc8343f0a7be0c4593",
+        "IPY_MODEL_1821d1962e3a44a78fc36c3e8d359b1c",
+        "IPY_MODEL_bd448efd86884bf383a7cb665823ac53"
+       ],
+       "layout": "IPY_MODEL_0ce8fea7f31f4a44a674824c7763b015"
+      }
+     },
+     "16129b9ec1a24340a0f7a4c91c688595": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e5c0bc1581dc42d69cd5eed023a8a3d2",
+       "style": "IPY_MODEL_f0506af07d8446cd869323b797bac3b5",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.inclination_err.fits: "
+      }
+     },
+     "162b6ff520c3457382d5a8bc72154547": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "166a2f8e2f5840528fc487c13f345a55": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8359284f5bf14720be3fd335a62426f4",
+       "max": 1353600,
+       "style": "IPY_MODEL_4313b14bf1f9425fa863998d6f37550b",
+       "value": 1353600
+      }
+     },
+     "1671cf2608314663a06e4786d36bbd9b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_147c5fd132d648448d23b98890b35ecc",
+        "IPY_MODEL_91a1c575af1d464eb3e81bd2d1dd076c",
+        "IPY_MODEL_6455ffb778974bfaaa0c199c41d64bae"
+       ],
+       "layout": "IPY_MODEL_328dc864924447178a4314b6780014b8"
+      }
+     },
+     "168c8b05368d402494f58d0c290be5a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_704603a340c94ee28d74b31fcd449b3c",
+        "IPY_MODEL_afd62351847349eb9bffe283e91d9a1d",
+        "IPY_MODEL_83915447e6514ac1bc0a3277dd61cbf4"
+       ],
+       "layout": "IPY_MODEL_1ac4b4b3dac84cdea73efaa18a05820c"
+      }
+     },
+     "16c7a54018f14e0c8ec57a4a80062487": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a162d79c3b0e4d369ec3774fbd0a2b30",
+       "style": "IPY_MODEL_20d08abd355942f4be2900b923d77c00",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.Q3.fits: "
+      }
+     },
+     "16eb5a016a90421c9ad584366adc3fc6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "16f30a7dfacb4fca83ea3712c101bf43": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_1d911cff182540b8b0c767c851972112",
+        "IPY_MODEL_ad0b5dab15bb4d5d87bb41c967c946c6",
+        "IPY_MODEL_651a0c9e0bf748d6abd1bfca56501134"
+       ],
+       "layout": "IPY_MODEL_6efb7360717f4077abc4445abc43ade2"
+      }
+     },
+     "17152ef9458b40b9920afd14f6b494bc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "176047dd8a5f4e1a83a8682b8b5e54f9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "17670e81ceb749e89dcbc9ed3d052fe1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "17d94e9e8f5547539dfba8edebe90120": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e1b812d079e945599a4a468032d539d6",
+       "style": "IPY_MODEL_479507ca35f24b8eafca7c1890b24cef",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field_err.fits: "
+      }
+     },
+     "181009e56df64d35af8222d5e29091ae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1821d1962e3a44a78fc36c3e8d359b1c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ff622c4642584faa99223fb2199a8390",
+       "max": 19209600,
+       "style": "IPY_MODEL_7ccbc64acb0e40ad80f5ca6913bee772",
+       "value": 19209600
+      }
+     },
+     "18220d85d0d3472fbb326946a1e69992": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5e0dc425e1044f44bf4ec85c07e4ffec",
+       "style": "IPY_MODEL_73795a2c7bf245b9a5cffdaed325b63f",
+       "value": " 1.35M/? [00:14&lt;00:00, 2.01MB/s]"
+      }
+     },
+     "183c7fb9a11d43f29a658c51755a826f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e5d0318667d44b06b7e3b2f36a9715ba",
+       "style": "IPY_MODEL_896dd0d8b4b74720a1d6343c5da6b1c7",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V1.fits: "
+      }
+     },
+     "184ba17c3b434a039c1e663c4ec36236": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "18a0b57b99a24d0897f778566b3aedf4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "19045c38e1a744af94f35bf4dddaedd6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_56f2dfffd7aa43cea3a09bb4424d7cd6",
+        "IPY_MODEL_b36c62195ccd49a7a1ca66bd721be41e",
+        "IPY_MODEL_4861aadc18f64cf1b51f6e208a5068f6"
+       ],
+       "layout": "IPY_MODEL_910b370069c5499a8a2513732de38274"
+      }
+     },
+     "19318d5744e84a049289a0e8e15e32f9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_b547b70f18504660ac826a22528a7337",
+       "max": 22800960,
+       "style": "IPY_MODEL_5357edc85c2547448380767c091848a1",
+       "value": 22800960
+      }
+     },
+     "193ea3aaea7c4af98099e004f14e330c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "19581f2b54c146b0a96f0feedea44660": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1968d23d17e54d36ae1bd9d56faa26f4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "196c2532e35d4c09a4498ddad3d03f23": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "19ba2a25d1fb446890269bbf0ebcd4b6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "19c3d709be834963894f48b5393ad120": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_869b96db257144339d034fc7656ab784",
+       "style": "IPY_MODEL_060dd493513c45328abd494f8de30f47",
+       "value": " 10.4M/? [00:22&lt;00:00, 5.41MB/s]"
+      }
+     },
+     "19dc0b63fbb74bb0ba0e86c0fb4fd301": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1a1d73cd62dd445cbbb83b681b7790a1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_9fe08c2b25984cadb5f8d93e98a41313",
+       "max": 15163200,
+       "style": "IPY_MODEL_d5debb73ad4341bfa2c2656de76aee10",
+       "value": 15163200
+      }
+     },
+     "1a6f841a849c42b09b61abf3a59f1df6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1a84f98765564bd8aa9c3ca6430838be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1a9db6d8bf0e4ec496660944edc47523": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_2581b9dbb32a4408bd3ad49cd25fb128",
+       "max": 14705280,
+       "style": "IPY_MODEL_d38c2fe969cd4e8cbb25bedf246a700c",
+       "value": 14705280
+      }
+     },
+     "1abb4acef16b431b934a89c4f0e4d44d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9372696bd8e54942a4f1f0d21413f233",
+       "style": "IPY_MODEL_92a9c4567f3447698388c2b31b35ec4c",
+       "value": " 24/24 [00:02&lt;00:00, 11.03file/s]"
+      }
+     },
+     "1ac4b4b3dac84cdea73efaa18a05820c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1ac5817999ab4d16bbddd392bcdb12f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1ae32a4c882548d6ba199656073af7a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_83470dd5380e44a098e89704f244797c",
+        "IPY_MODEL_d541fa821e74413aba6beb82c29a4aaf",
+        "IPY_MODEL_d2715076b7d84dff95a50ecfcb2d945f"
+       ],
+       "layout": "IPY_MODEL_88c40ff77235462cafc35450b14be0f2"
+      }
+     },
+     "1af824c3bbb24732af881ed5a2198448": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_a1fb2009f9c14364803a5002584393f2",
+       "max": 1353600,
+       "style": "IPY_MODEL_efe99aeca6af446db72f077ad5b4231f",
+       "value": 1353600
+      }
+     },
+     "1afa4c19bb454153b404b95906bbed0f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1afae30a8bc04af781c8e852f3cc67ec": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1b120fef0d004905858e738b0a4080bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1b16a0dbe85c4b6a8fd5320e233bd77d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1b441c330815452da0ff0e8201dbe4a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4f217a7d684847da9f6b9e9639ba6fa7",
+        "IPY_MODEL_cbe62281a786431483542deb534acd3d",
+        "IPY_MODEL_f529bce1e2834821ba132845bb4d093c"
+       ],
+       "layout": "IPY_MODEL_beebd9215d784c6d876a99df24c2e323"
+      }
+     },
+     "1b498d20a9be4a7c825093749a1f9808": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1b83da54b458432ea69c343995cbd814": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9ebda3797d0e471ea8bada398f6ed570",
+       "style": "IPY_MODEL_f0506b13362e46e7bf733fc42bd569f5",
+       "value": " 20.5M/? [00:19&lt;00:00, 6.95MB/s]"
+      }
+     },
+     "1bada12a195b465db35fb804e0a649ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_f5290fe1b58d4abd9ee3492c780f480c",
+       "max": 1353600,
+       "style": "IPY_MODEL_a58cf63c6b0b470589250d75b7498869",
+       "value": 1353600
+      }
+     },
+     "1c1d06facea84a64947caac815c8c9fb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1c1dd903bc0e4cf98cfb64e74dddee05": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1c2a10caecb745dbaf2edfd852ff7c9d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1c621cd6719b4059a7585d4659deb35a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a2509d707dda421baef3ace2f0033f89",
+       "style": "IPY_MODEL_9d0ffcad67a244858feff9353b7a1223",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "1c785b5d54b54d588abce4784df29c81": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1caf0d6b9b2149f9bd35ae2d1183cff5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0643e86c7440435fa792c0e5ec7c1bb0",
+       "style": "IPY_MODEL_338ebf64520f46d8aae851c7cd1ab089",
+       "value": " 1.35M/? [00:13&lt;00:00, 1.76MB/s]"
+      }
+     },
+     "1cd172b0a5b4435486f688b5a3df1e03": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1cfc0ca8c3e9484c96e40106ce4702b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_95bd6103acd34f72b2e8aa8c0bfd50a4",
+       "max": 21530880,
+       "style": "IPY_MODEL_317c7c6defa648ed863cf99febeb61d2",
+       "value": 21530880
+      }
+     },
+     "1d13ce6c2e634d65a51dcb175562be8c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5b3fd59d1aeb412e8d723eead3ee1b9a",
+       "style": "IPY_MODEL_10595644328a418096ad1efb7831a72e",
+       "value": " 22.8M/? [00:19&lt;00:00, 10.0MB/s]"
+      }
+     },
+     "1d2f035313014b6a825b151b78b975eb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a27b2e7fa26240dbb0788a1a9cb8bda0",
+       "style": "IPY_MODEL_6dbd775a355b44f0b78bf747a72a85cf",
+       "value": " 25/25 [00:02&lt;00:00, 11.90file/s]"
+      }
+     },
+     "1d38bd6d1962405d9be5c0bf52547977": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a1376470833443ca85e15de457a26ec5",
+       "style": "IPY_MODEL_f29f8f127e79402daf3dce0728ac202b",
+       "value": " 8.76M/? [00:19&lt;00:00, 4.49MB/s]"
+      }
+     },
+     "1d5e8819164e401e9c68fa5dbd7802e0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1d7f7f3fd5774bbc8a3e84268b2bdc35": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d264d6f7c84c4959a47f20f75d0f23d6",
+       "style": "IPY_MODEL_54af2676878c43a483e4d7b819a2a608",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "1d911cff182540b8b0c767c851972112": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b93c82e4550c4b66adb14cbc5b8ed731",
+       "style": "IPY_MODEL_2409f1964c9944848ce979057243e37a",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V0.fits: "
+      }
+     },
+     "1dd11c87419a44b785e94138392a2bc2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_907bded6abea4fdd9d60f527005ebdc8",
+        "IPY_MODEL_938ea2cfb85f4debbeeddd1211bde67f",
+        "IPY_MODEL_a48f799f7ed445b7aea7ff6502098f9c"
+       ],
+       "layout": "IPY_MODEL_4555f9a7e1e64ca9b31c9afb3f8ce457"
+      }
+     },
+     "1ded27e7190f425992b8c0ae1def106f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7fefb175e64b4d79b7986561c52cf804",
+       "style": "IPY_MODEL_d296c88bf0cd4b8e91a530f2835a9a73",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.vlos_err.fits: "
+      }
+     },
+     "1e22acc0ee3941169a5f4bfedd8198dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_845f67c9b98e4d2c8afadf103524b9b9",
+       "style": "IPY_MODEL_8c305f0a403c4c308f5ee226963882cb",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.inclin_azimuth_err.fits: "
+      }
+     },
+     "1e2b380bd953485dae84c44f408f59e6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1e2d01fedae7489183be2f48132841aa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_139292607cc8415da0c9385a7dad7523",
+       "style": "IPY_MODEL_287e502440024e6d94ce259b2136fa01",
+       "value": " 8.76M/? [00:17&lt;00:00, 1.74MB/s]"
+      }
+     },
+     "1e3e29fde5de471dbd433f144e7f731a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1e601f9283564f61a76971c1a0fb7e9d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1e7cce1b76484bc39f3a1c0440f0f346": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_aa8aa7b7190b4e2cba6674624ce7f992",
+       "style": "IPY_MODEL_744a8d44d14c4f48a6b9d32a051a3727",
+       "value": " 16.1M/? [00:14&lt;00:00, 6.07MB/s]"
+      }
+     },
+     "1eabb108c76c433eae4b665af883bd88": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d289dc24da7545428e3fdc43e1f4f301",
+       "style": "IPY_MODEL_fb4706b7156541b4a0c9cdc9a7ba3fa1",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I2.fits: "
+      }
+     },
+     "1f200807fd3e49169ca87de43a43a423": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1f209d6d98e548a2804d6f0baef128f3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_176047dd8a5f4e1a83a8682b8b5e54f9",
+       "max": 9547200,
+       "style": "IPY_MODEL_1b16a0dbe85c4b6a8fd5320e233bd77d",
+       "value": 9547200
+      }
+     },
+     "1f3f6343740d4dd2a06fad474afc17dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1f49ad68dcec4d788a0c26228f089b39": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1f589064c35a40d2b14f26df19c12b4b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f0120781641f498ab8d5379462ee3ee9",
+       "style": "IPY_MODEL_e5d7bbae5165478aa7eae668bbf29f92",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.U4.fits: "
+      }
+     },
+     "1fa74f72a6ee4723a323afc64a1e8c29": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1fd29e9193374c1582b30daea1df5f08": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_9a91a470f0c245f3b5dcdf103db617cc",
+        "IPY_MODEL_1a9db6d8bf0e4ec496660944edc47523",
+        "IPY_MODEL_ba12c33d628a4733a0311bc4b645f109"
+       ],
+       "layout": "IPY_MODEL_8ff671458aae43a983cd5902ff7b5e67"
+      }
+     },
+     "1ff4ee4ce6874ff58383431f56af63a8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_39bb37285a9246b8b24534e380ad5304",
+       "max": 48,
+       "style": "IPY_MODEL_65413e2d90364853b7aa3341896e8d5d",
+       "value": 48
+      }
+     },
+     "1ff76e5388f94d30a01d40568247e6b9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9d2c0eaf8769407786fad9c0177e266f",
+       "style": "IPY_MODEL_aff835e0ed254c47896bf34db1d32652",
+       "value": " 25/25 [00:02&lt;00:00, 12.04file/s]"
+      }
+     },
+     "20010c3944c440ca8aee4721d37279bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_8d4824acd5c54456807182971e3dd741",
+       "max": 48,
+       "style": "IPY_MODEL_b6b8049a90864dc0828feed58bd39ba9",
+       "value": 48
+      }
+     },
+     "202ce5501d644127ab5cb9841d9b7f41": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "20397dc97efa45f49939c35c99e8632e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_5816ab5c744b4a08803ec73337467b17",
+       "max": 9731520,
+       "style": "IPY_MODEL_5952a072246343238e43d6f83e0c58c5",
+       "value": 9731520
+      }
+     },
+     "20882e82ce4041a48c63f601fa720a90": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_1c621cd6719b4059a7585d4659deb35a",
+        "IPY_MODEL_02421d49f8f1467da076032367c6ae2b",
+        "IPY_MODEL_1ff76e5388f94d30a01d40568247e6b9"
+       ],
+       "layout": "IPY_MODEL_34915b1e055c4c76a2ba8cc8bd263c9a"
+      }
+     },
+     "20a14acb51924c11808cce967c2fe207": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "20a2c1d6da81454793c7ade2cb0f33ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "20b6ac165d144aacb83d2a7b6983663d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5670c610c93a41c9a32c2b021853ffdd",
+       "style": "IPY_MODEL_223c4d289a894d7ebe2b1d57d296a624",
+       "value": " 1.35M/? [00:16&lt;00:00, 1.84MB/s]"
+      }
+     },
+     "20ba1c45a21f4c0c984d56da365730f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "20d08abd355942f4be2900b923d77c00": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "20fd522bf2b2405e810357a07f2c5720": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "210b4e33a8f44c27a7cae77f5f645a5d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "21301d2f03ed49c2b362e0a5dc209bec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_8ddd17cd395141138dc0f370d28970c8",
+        "IPY_MODEL_979e1558f1d246f28318bb2581ae3509",
+        "IPY_MODEL_5ad80ad5f59a48da95917c7b18c0d62c"
+       ],
+       "layout": "IPY_MODEL_2c3208452bfd488cb6e0f6e577d9e507"
+      }
+     },
+     "21352630adeb4ceb8172f195f4eb559a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "218c3ce634bd4f8a83390523153480fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_67c72c7231114327811b5dc7d4967015",
+       "style": "IPY_MODEL_6bf3590b39214e4aad411975f706f2b0",
+       "value": " 9.60M/? [00:18&lt;00:00, 2.70MB/s]"
+      }
+     },
+     "21a37622a97e46d3befb65bbca285fe0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "21cc435eafbe49cb8778d09bb571c2d5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "21d3284cbcb148b5abe07903d2c20d05": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "21e12b1a0b52494b9dc948e108f3df7c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "21ec717dead0415da2f2b80fe229bf9e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "223c4d289a894d7ebe2b1d57d296a624": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "228f785b197e4b25ac7ebbb1681cb892": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "22a04fb6ffa74990b889870895a9df7b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "22f57e2416314f0380f9c591edbcadb3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6d8523c1ecba44be8c3b6dba15ae2a0c",
+        "IPY_MODEL_a9b582e46fec4e11be25afa4e9facc3f",
+        "IPY_MODEL_84163155f14b4e8eb60d79d844d5daa0"
+       ],
+       "layout": "IPY_MODEL_28da69e6a6fe4be69146caf5fc3d0831"
+      }
+     },
+     "22fe94a518764ad1b5cd671ae69d4efb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "23029e56c7014015ab9e41341fea3a8f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "231a8b0de70446808734ed1fc2f31f1f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_cd84526c4dd044249e879015b7743cc2",
+       "max": 394560,
+       "style": "IPY_MODEL_0e0769edbf604a67a7f093d99d5eb696",
+       "value": 394560
+      }
+     },
+     "238025ce083e49649b8991771f1d1a3e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "238b4d2b40334d20a7719c3004b7dc22": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_eb1b0257b116494597ecb2956b7f3fc4",
+       "style": "IPY_MODEL_46a7302ea1824f2fb297d481241ee4f0",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.eta_0.fits: "
+      }
+     },
+     "23b3218f2bbd4a2398c88b5c21b5be36": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_dc148c8244714a6fa44a9ebf693e8eca",
+        "IPY_MODEL_166a2f8e2f5840528fc487c13f345a55",
+        "IPY_MODEL_d160e9c2de5f4051bfb6aa87e04cf20c"
+       ],
+       "layout": "IPY_MODEL_74efcef938c448888d36d509457c086e"
+      }
+     },
+     "23d21f8913d343fd910f916b301f7a6a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "23d37d49de824b4ab211eb287bebd5e2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7d5be8fa4af64c5b8c09c861948de930",
+       "style": "IPY_MODEL_5fbf686ad511465786b1d6735b52c082",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field_az_err.fits: "
+      }
+     },
+     "23e8435fc53e44b5a1a4e56a60d12b74": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "23f3d7a27ba249f1bfba0a5115777d52": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2409f1964c9944848ce979057243e37a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2418437c5b654836bb15349014c1310c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "241953f4640f4a51bf13de021883f0ad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a817d675746245e18efb2e6850ea38ec",
+        "IPY_MODEL_44679fcb1e1d49fc8216d06ddf15b90d",
+        "IPY_MODEL_7eff607d1b7c4531aa371073de87718a"
+       ],
+       "layout": "IPY_MODEL_3c96a321e39a45d8845a17f3a2928767"
+      }
+     },
+     "2458132c3a314ffeabdaa62cd71afee1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d45ff76970d047afa859211feefc5f35",
+       "style": "IPY_MODEL_88e7c11b73b54ccc9402f872848b05ae",
+       "value": " 25/25 [01:25&lt;00:00,  1.56s/file]"
+      }
+     },
+     "24591296619845f8aad159dd9ec00087": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "24a0d338b8bf4127a9bf8332c2ac9b49": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "24abd26f95e944f4a542da01587b3850": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_d046c575407645f19842c50506a2e417",
+       "max": 285120,
+       "style": "IPY_MODEL_cf4f71e000f544f8884fcd0bd948e759",
+       "value": 285120
+      }
+     },
+     "24b3bfcd18a94550b93a476806a7c4e8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_62a3f8ef40164644ad72cf479e2e15e1",
+       "style": "IPY_MODEL_eadd9f3f9356448b9dc8e70bcf191017",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "24f66ff10fed49a5ae34bbb118b12975": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_ebc35a8ab35745009de2bcf9f59a8339",
+        "IPY_MODEL_5a4cd27720184204babed64925b37d1b",
+        "IPY_MODEL_3f385775175c42e4b934bcd2331522c4"
+       ],
+       "layout": "IPY_MODEL_2be499d8a0454058aead2874cfb9a134"
+      }
+     },
+     "24fe5af80b3c4bb8a6f0c52f9f89383d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2516334319d448d798d24c1998aa4f0e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "251fa70901bb4697aa6f79ead2a199fb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "253013e9e1b545e5889c67682a15bf74": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "254d0e83768a46a7ba5a1890614872c5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2569b61d6ae0450bbac22e009a4fd0f6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2581b9dbb32a4408bd3ad49cd25fb128": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "258aaec2fb8d4b46a019a6b4bb05538d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0e6ce4ad942648c9bce24331e2cffa08",
+       "style": "IPY_MODEL_df619886c9bd42f38b03464d82423ba9",
+       "value": " 9.55M/? [00:20&lt;00:00, 5.89MB/s]"
+      }
+     },
+     "2593c4b5fb2241259e514a3f7aa162ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_dc5bccc710834d55a8c37c80628f1519",
+       "style": "IPY_MODEL_fd6ec000fcdf413cacb15d58b81678b2",
+       "value": " 8.99M/? [00:12&lt;00:00, 4.72MB/s]"
+      }
+     },
+     "259bfe05ed4e432787745cd7fe78f91f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "263076f020ec4ef88395ac0aef86eeba": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "263b9b14310d4e52b14d20d53e9d3aa0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "263e3d2664b4454786de3fc69cd8d452": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_19ba2a25d1fb446890269bbf0ebcd4b6",
+       "style": "IPY_MODEL_cd867370fd2d4672a3b7480bc16df8c5",
+       "value": " 21.8M/? [00:20&lt;00:00, 7.14MB/s]"
+      }
+     },
+     "265009329b084248a0a8b8dc8b7c4e93": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_651f8e9f80304814accf8290a0bf30b6",
+       "style": "IPY_MODEL_ee98aaf22837408cba6887674aa9ae77",
+       "value": " 9.71M/? [00:22&lt;00:00, 5.65MB/s]"
+      }
+     },
+     "26712e80178e4243b8f5684fbad79ce9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c6e352e0a5e2447d8b974864b67c5128",
+        "IPY_MODEL_de34b7c7a712470a98b288c28173de8a",
+        "IPY_MODEL_0697177b408d410082793d9856e98df4"
+       ],
+       "layout": "IPY_MODEL_b8914b0aeb8049f2821e5db34063c3eb"
+      }
+     },
+     "2678c7d0a31749b8b90ac5b21003e507": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1e3e29fde5de471dbd433f144e7f731a",
+       "style": "IPY_MODEL_7d5bbe66ca364133aba95dea065b5de9",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.azimuth.fits: "
+      }
+     },
+     "2688713e31244f7cb6ddec2974e8e6f4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f2d1fede24754fd4921d8dc14444af66",
+       "style": "IPY_MODEL_8adce10e13704cc4a833b08bb9617cdb",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.U2.fits: "
+      }
+     },
+     "2698ad785bdd4ee5bd1fb6cac782e8db": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "26c80fa676df428cb3ad2afd012f9a2b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8071124769d64521a2a0ed9b841381c5",
+       "style": "IPY_MODEL_c3b74b52354e4f0da5434a61c782cab6",
+       "value": " 9.73M/? [00:19&lt;00:00, 5.31MB/s]"
+      }
+     },
+     "271586b89d1f4fb2915ef39bbe8e2a4e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "27751caec3fc4e70a0a5b3493f90c578": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "277f4f18d60d4c7eabfaafce23c765d3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_228f785b197e4b25ac7ebbb1681cb892",
+       "style": "IPY_MODEL_37b72682027a466b9407af2ac5e1785e",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.V4.fits: "
+      }
+     },
+     "27a0be5c2e6d4746abbbfe21545e306b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "27a3cf525d0b4dbcbff2ca842e76e1e7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_838d8bc4a6cb42abbcce46df59664110",
+       "max": 14846400,
+       "style": "IPY_MODEL_98d10a4c1d884f51ae594ff762b7569a",
+       "value": 14846400
+      }
+     },
+     "28286b70a5cc48d5906e976103d7dd3b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "282bb61500284e5fb75ce7a6f771d1e2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8300698336fa44fea20a43b36d8b5483",
+       "style": "IPY_MODEL_94c89c11f9dd47c69ab5e7d24454176d",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q4.fits: "
+      }
+     },
+     "286360e68e0840b2bfac1617e31ee2c1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_2a0e4ad6df3a4aacaffd7631106727ff",
+       "max": 394560,
+       "style": "IPY_MODEL_4e89b2be71ad4ceb831d93858df4b8f3",
+       "value": 394560
+      }
+     },
+     "287a56d72f4a4742a0e804397db01c5b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "287ad18d2a8e4aa5881f47b2b1bc8687": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "287b10958a1b4a17a45989578830b352": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "287e502440024e6d94ce259b2136fa01": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "28814f5e16244e7499996096f46d06ef": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2885d1d249ae476ba8f5caea2db496e5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "28bcadaa8a4f407bba27b4909b3a0e46": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "28c1d8ca7ad044a2b52940640104e3a5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "28da69e6a6fe4be69146caf5fc3d0831": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2903b00915204cd1b16b98cf3994ace0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c193906b54c4436f95a189fe41addf19",
+        "IPY_MODEL_3cc6bb02a86f4e749f1a34e5e4a7c439",
+        "IPY_MODEL_ebbde158d326426586a389ac40d4e65c"
+       ],
+       "layout": "IPY_MODEL_c279809e671647048c32e0aff60e2c6e"
+      }
+     },
+     "293bc94b50794375951830b578e30423": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2944b38c6cbd4a35bf011c258dafff7f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "295cea7e5c6c442a9c61008480aa6d4d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_100e46f20af04acf96fd6efdae94c6eb",
+       "style": "IPY_MODEL_7f08ae04ac99423fa487be8964db9c2c",
+       "value": " 24/24 [00:01&lt;00:00, 12.71file/s]"
+      }
+     },
+     "2a0e4ad6df3a4aacaffd7631106727ff": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2a6ae473b63c49ae8eca1c3cb1415a89": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2a79ebb392034a03be46ae95faa299a8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2a833cabc224468a9bfa4d40df6eef84": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8c0b402425124db2bb930420e52ca095",
+       "max": 9705600,
+       "style": "IPY_MODEL_46cab88e122a4ac3a99849b2d5539990",
+       "value": 9705600
+      }
+     },
+     "2b55e04a16b5475686e262eef900f2bf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2bacab27932143e8a0af4698f22ae857": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2bd220b575b84ea3a88490275adb2f7d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_5944f3c56d414491b411230fb11c109a",
+       "max": 15163200,
+       "style": "IPY_MODEL_3c4eca840bc442f1805e82350607bc7a",
+       "value": 15163200
+      }
+     },
+     "2be499d8a0454058aead2874cfb9a134": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2c3208452bfd488cb6e0f6e577d9e507": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2c8046e9cbb74c6f886a9da8ccf84d3e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3591281c0e79437a9dc10846f41fe578",
+        "IPY_MODEL_51859dabb53d488e85f59901b1422129",
+        "IPY_MODEL_6b9f0bf33bb14218b6d6d187a6bd6dab"
+       ],
+       "layout": "IPY_MODEL_1b498d20a9be4a7c825093749a1f9808"
+      }
+     },
+     "2c82779e5b464e7d825bba1fcb329213": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2cb3c7d1bded4d399b4664d472be4be9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2cbe98c3a3f74da9ad4c6c84702aa80a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2d08072242d247718ac1ff546b03a3e0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2d2fcccb93b9465d999c5641f44d7c7e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a819fe1a866841ac9c933b262b96b1db",
+       "style": "IPY_MODEL_384701f253224f47b6b98a6e94b222f6",
+       "value": " 12.2M/? [00:16&lt;00:00, 4.02MB/s]"
+      }
+     },
+     "2d65fcc1ccbe4c66af931fe0ef26e993": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2d6ad1d66e5240bcbb6923615b2e5325": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ab47429010a741629a43b6e990827df8",
+       "style": "IPY_MODEL_cab15de1f5fa4478bacfea336b70517a",
+       "value": " 22.8M/? [00:24&lt;00:00, 2.16MB/s]"
+      }
+     },
+     "2d838ddae0f64d8aa8f99cb66c812fc6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2d934be1dff74b8b9d221cd45767adbe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_0ff978567d9746e2923c3acbb370ce16",
+        "IPY_MODEL_ab7e8d6ef48a4f838ea069896bbfea5f",
+        "IPY_MODEL_37a143fd2bb6458382d2d4c844106142"
+       ],
+       "layout": "IPY_MODEL_d7843d0997794a46a51ffdb7a4237298"
+      }
+     },
+     "2da4f9aa8491415089040f9cbca157e2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2e3d73f2aedd41f38756b24c313fc557": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2e3dbd9fcd6b44e3a88070887219c9e0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2e65151401d742068ffff25fc409799b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2e81efcc1f974ceea26e78622aca7992": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2f09e20eeea24877a72d79acf8c56bed": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2f53aceb1a1747ada086753f35d90a31": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5ff3a85335d44173abe18d69ed9b1e27",
+       "style": "IPY_MODEL_9bc4db1a868741ffb79e0e84f1cc975f",
+       "value": " 15.6M/? [00:21&lt;00:00, 9.48MB/s]"
+      }
+     },
+     "2f59911de876440f82b7ccfa2d5a739d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2fd78e52a2824e73b68b38432116bbc4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b743dcae1f1c4df6b29e2aef3546878c",
+       "style": "IPY_MODEL_da6c7d47e51342f6bf18e7fff17639c5",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I4.fits: "
+      }
+     },
+     "2ffe23975ce740f2b29041bd5c46762e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "301fd49cffcd494986c232d0170e7cfb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "303193aa449342889f6f15919b53bcbb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d08005cb3a84463393ff316ac110bf34",
+       "style": "IPY_MODEL_c60c77b1484d4774bd25ac59336ab384",
+       "value": " 9.71M/? [00:21&lt;00:00, 6.63MB/s]"
+      }
+     },
+     "30d8ff5fa1c04282a5f0a05ab2823b23": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "30e7e9943ce3492aa3199e72b4e94894": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "30eae71acd22407da11272c6cc696e3c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d2dfcf82f3484088a7ea535bd526b2e5",
+       "style": "IPY_MODEL_df67211c71ae4eadbd12aea9b8d2ad99",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field_err.fits: "
+      }
+     },
+     "310f8979543c4776adec79c6e50b7e8c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3119ac1ea9da494e9006491dda45b74c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "31385ac126ff42bea99a8400d7272693": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "317c7c6defa648ed863cf99febeb61d2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "31a43f0eb81e4c2a9a0ced0847363dae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "31a818eb5d734baaa53b91d5f9173629": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_864da73585f54b98aee9770bdee225a9",
+        "IPY_MODEL_5b6b24350a824d6c92380e10fd19c6a9",
+        "IPY_MODEL_dcddceb0d9874706bdc80d88eb550095"
+       ],
+       "layout": "IPY_MODEL_15312e9950d64fe191ef3bf87c4e03c2"
+      }
+     },
+     "31c3f4d7c2914143b487efee3300e847": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "31d3de5ca20d440baf8e3f6190ce35d1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c735f61d4da6461092e78ac68fe082ae",
+       "style": "IPY_MODEL_aa1b03a571fa42f88e4e132fe0d62cd6",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.conv_flag.fits: "
+      }
+     },
+     "3223fa83d9d24ac294ef6416f3f34962": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_259bfe05ed4e432787745cd7fe78f91f",
+       "max": 14929920,
+       "style": "IPY_MODEL_a58e0507469140afa705c8fc5003601d",
+       "value": 14929920
+      }
+     },
+     "32355910c78c4c51a090543f67603672": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3265491769f04899929a6d746241de8c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_824052b899d247baa6b25c6e0e6f4109",
+        "IPY_MODEL_09d450425ff5489b9a38f8e12453e71c",
+        "IPY_MODEL_ac928b8db250402ab95a155c621fd244"
+       ],
+       "layout": "IPY_MODEL_3b3c06281ddf4966a88f59ce8d01adaf"
+      }
+     },
+     "328dc864924447178a4314b6780014b8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "328e598e9e304612bcfa87fc53b0162b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "332a1b9182be4bfc986a12d288ae94a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c98f293241c84c6f893931a579c69ddf",
+       "style": "IPY_MODEL_b013e5cb48bc4f4e87d962c0ce6e19f4",
+       "value": " 10.4M/? [00:22&lt;00:00, 4.82MB/s]"
+      }
+     },
+     "3339b8ec4b5a410e910fb07609430fa9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3370c192b18348a9996e5614e353aa61": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_13751b6c522f4008ae50cb4aa5127b92",
+        "IPY_MODEL_ffef82145b0f4681ac2faf54994695fb",
+        "IPY_MODEL_cb94e8e45e564eaf84ab546d9f6349b5"
+       ],
+       "layout": "IPY_MODEL_ce025f63db23454085092611bbbe958f"
+      }
+     },
+     "33807325b70a43199f36caa14f7ac1a8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c4941bc4b4bf48d5ad233511c84e6615",
+       "style": "IPY_MODEL_fd508dfe690c4deb973d685f9fbb03b8",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.alpha_mag.fits: "
+      }
+     },
+     "338ebf64520f46d8aae851c7cd1ab089": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "33aa6750877b4bb5baa720ba4ab7074a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "33db5ac8b8e945bab82016f9df58353e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "33dcc82fc4ca4855a80bdac875fdc580": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "33ea84f1ae34471385d7724d7b3278ba": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "33eda21075ed495b964568977a512d97": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "341d6ef74bc24e27aa1879b6674d324d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3429c929c82249588a30078cb461c25b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b0f59c3336474c4b93d0702082efd9a4",
+        "IPY_MODEL_7d3c21301aa84887a24a729d1e658cc7",
+        "IPY_MODEL_18220d85d0d3472fbb326946a1e69992"
+       ],
+       "layout": "IPY_MODEL_514beab8aeea464ba9627f14c17af77c"
+      }
+     },
+     "342cc0a2791d42bdbc29766677ef3da8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_004a5dfaffdc4a4db92fd53dfea4bfad",
+       "style": "IPY_MODEL_1f49ad68dcec4d788a0c26228f089b39",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.azimuth_alpha_err.fits: "
+      }
+     },
+     "344c648329174fe88ca7f7c9d5482d1f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3472fc8f32c54c029e959a9c8d6979f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a9467ceaf1b542718df9c77111748a7f",
+       "style": "IPY_MODEL_387ed8250efe45cea090d6bc58916bc7",
+       "value": " 395k/? [00:19&lt;00:00, 756kB/s]"
+      }
+     },
+     "34823ceee9464590bb85d3678ec8153d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "34915b1e055c4c76a2ba8cc8bd263c9a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "34931c65d44b418c968743b8a402bc00": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_918068903cbe498dbeb610e96a5809fd",
+        "IPY_MODEL_d01a1de15a2642a6989235866c03cb86",
+        "IPY_MODEL_01537159d4a64d2db0b9c5cb222e59a7"
+       ],
+       "layout": "IPY_MODEL_1f200807fd3e49169ca87de43a43a423"
+      }
+     },
+     "34abb7e5068f49799e9761252950f59e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "34c8eebe166b4fd79c729b65265e44af": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "34f1af79616d4f0387793cb5ace7c634": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "34f9f5aa466649f1a1055fffd7b97cbe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3508b2ccfb574e67ae49189c0ad870f9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_301fd49cffcd494986c232d0170e7cfb",
+       "style": "IPY_MODEL_0d77e5fd10614d1c9b462facd168e97d",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.U5.fits: "
+      }
+     },
+     "3521b8b376e44494b94720ba433f60fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "35238592a9a4459facee15eaf612cce5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "35535572449241168b1b7567981703fb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4507e5cfbb2e43caa1a9cf310d5167c7",
+        "IPY_MODEL_ef6d0cd2293e4e769c90d5eb43dcd9e2",
+        "IPY_MODEL_6eb85c96bd9d40e390547fcea3e59f2d"
+       ],
+       "layout": "IPY_MODEL_dbf7de19c9204d5c85af0e01b5cdea66"
+      }
+     },
+     "3559c208a50d4bc2adfe74dd5080a936": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "35747eb4983248359adf8ba9d45d8b07": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6908060df2604a2eab16d637e3ce67e7",
+       "style": "IPY_MODEL_fb1f300b86964dc08ed89e4242f28e45",
+       "value": " 8.99M/? [00:20&lt;00:00, 4.70MB/s]"
+      }
+     },
+     "3591281c0e79437a9dc10846f41fe578": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0901e43f51e84dd8bbb3dfc6aa02f174",
+       "style": "IPY_MODEL_3d0996a48efa4423a7b6afbcc0773081",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V2.fits: "
+      }
+     },
+     "3591c05419954712aa387ceafd4e754a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "35d3706daec44500832b40a61fbdb94b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3610e89a1dc1420fb8124d0032c8a0be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "363a8128517141dc85d9880a8da8ba17": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3655db44a3d542e7b0df198e61f0690c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_30eae71acd22407da11272c6cc696e3c",
+        "IPY_MODEL_ecf112e94c7f474b8c620938a2783c5f",
+        "IPY_MODEL_930d7e55541d4642808ae762de3b6801"
+       ],
+       "layout": "IPY_MODEL_d82affa3f89c42b9a6528968bd62d0f0"
+      }
+     },
+     "36c87335180d4e609e2aa2e57cb132b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ad0924953f444082b4598ecf5b6e061f",
+       "style": "IPY_MODEL_5d7c08fab6184fd39cd5c48fe47fe567",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U2.fits: "
+      }
+     },
+     "370eaf3f85f84b09a64601d86d9cfaa2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "378f26ac37ea4a9294d80f821d988843": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "37a143fd2bb6458382d2d4c844106142": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_396d0c45509e49b1843b4205bfc20878",
+       "style": "IPY_MODEL_1c785b5d54b54d588abce4784df29c81",
+       "value": " 9.73M/? [00:16&lt;00:00, 4.96MB/s]"
+      }
+     },
+     "37b72682027a466b9407af2ac5e1785e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "37d3ff51947a40e2bd0b45d43feafc68": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e79cdbf39c844f1cab664881c64db653",
+       "max": 2900160,
+       "style": "IPY_MODEL_c4f7475a51d84b528ac55674ec6fe9fd",
+       "value": 2900160
+      }
+     },
+     "37dd56f7d0fb4e47aa4e23edfa96ae9b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a9179dd1eac74b6ebac3b43c0ca04df6",
+       "style": "IPY_MODEL_e4bfc44366504bd9938844d770d22fa4",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.vlos_mag.fits: "
+      }
+     },
+     "382b7991b7b1452d9a8ad3b0d9dd59e3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3845c0eede3f441a8169a36b3ff10c25": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "384701f253224f47b6b98a6e94b222f6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3852d0b5cf6740b98e6ba31577f41438": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_9348d1483f6e48b887ed5299c889ccbc",
+        "IPY_MODEL_e2757ecde8974e7eb4266b92ae2e4743",
+        "IPY_MODEL_704c724db1154475bb4b5d78150ad086"
+       ],
+       "layout": "IPY_MODEL_ca5f97184b9648be990d48e4b5da9552"
+      }
+     },
+     "3855465dd9114c36ae2e454025c2c46b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "387ed8250efe45cea090d6bc58916bc7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "38867bdd98f9438e9f2620c0a9c9a849": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_f781e851b59f4e3d9011a56d962f2f81",
+       "max": 1353600,
+       "style": "IPY_MODEL_28bcadaa8a4f407bba27b4909b3a0e46",
+       "value": 1353600
+      }
+     },
+     "38b9aa465200457b9943a5c660a347dc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_33ea84f1ae34471385d7724d7b3278ba",
+       "style": "IPY_MODEL_2c82779e5b464e7d825bba1fcb329213",
+       "value": " 24/24 [00:01&lt;00:00, 12.39file/s]"
+      }
+     },
+     "38c6a0c7b503473bbf991e9d5ba83eaa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "38e64350e4364720a24e8af129b97f9a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "38e7a476989545259627bc6f9649432e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "39133619e9474f3bb8d2a5a0b7029ee0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_c9db5f71a0ec4fd39167ee0e50a9b000",
+       "max": 16067520,
+       "style": "IPY_MODEL_bedf824a9be04ef5b5cae09db8028690",
+       "value": 16067520
+      }
+     },
+     "395cd50b27924e07b4a8205001548d4c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_f07e1609b5584c1aae73955c0622d7fe",
+       "max": 12202560,
+       "style": "IPY_MODEL_e492d50cedbc4b0794c232d4b102c6bf",
+       "value": 12202560
+      }
+     },
+     "396d0c45509e49b1843b4205bfc20878": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "39bb37285a9246b8b24534e380ad5304": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "39cfa600c5a64632b690f22d533d67ee": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "39d442dec2444195a7f92a2b33976519": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "39d492aef3a44308ac5cc55d3c0959e2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3a13233cba6a48b9bc6d4fd02548a38e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_484c3e46988b48fe815ba3cd2deb693c",
+       "style": "IPY_MODEL_58c4257adf934b859cd6fda00471bd19",
+       "value": " 9.73M/? [00:22&lt;00:00, 4.45MB/s]"
+      }
+     },
+     "3a3a8fea322b470c8741198f0490c796": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_c886ff38cdea41d297b6f8b39b807675",
+       "max": 8657280,
+       "style": "IPY_MODEL_83e9cbb432d047fb8e4844ce2fb82609",
+       "value": 8657280
+      }
+     },
+     "3a442cfce2454bf28e916ca0a6cfe953": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3a4cb051f5d242b89758d0236c58d67b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3a841ed72d6046d08afbf84395f2ea15": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3a95bc4b66c5441183991f76b511ea00": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3a9b53d3845a4c379bfa64556ade7b61": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3ef540c29c6f4f9e9bb27b4dcfc57af8",
+        "IPY_MODEL_4d19370387184a68850288c282c03951",
+        "IPY_MODEL_71a4075e7bbc4b22b01e93b6165203f8"
+       ],
+       "layout": "IPY_MODEL_02eca571cd284f80affbfa050b7067e6"
+      }
+     },
+     "3acd01fb884d45d98e7a822ee41f31a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_39d442dec2444195a7f92a2b33976519",
+       "style": "IPY_MODEL_ef521e85cba94a09aa86d8bdfe480439",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.azimuth_err.fits: "
+      }
+     },
+     "3ae358df4743445f88fd524013bac439": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3aee5124438d42a9aff85a1c67fb8624": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3b1800af713548a8b0b4a966594f99f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_aabb34e7599a45e69c5339c620ef5464",
+        "IPY_MODEL_9a2be989d354483fb549b01a49b7b279",
+        "IPY_MODEL_7072490ff38940aa98e9deee8e7cdf8c"
+       ],
+       "layout": "IPY_MODEL_736945394f5c45819a69c3c8b07bd528"
+      }
+     },
+     "3b2895552aa34beca29cb8cd505b77b7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3b3c06281ddf4966a88f59ce8d01adaf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3b4d4e63b3e84674925a7d80b837fe95": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3b814a307ae1476d996538ed6edef925": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_19581f2b54c146b0a96f0feedea44660",
+       "style": "IPY_MODEL_921fb89aeb814f3e8c7514cb6d2f6c7b",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.dop_width.fits: "
+      }
+     },
+     "3bb79732978746cd90df2b485705f374": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b738f1fb847647e2b8fa2c3439933ee4",
+        "IPY_MODEL_7f7879b64d674b12b9452a1c85c9cacb",
+        "IPY_MODEL_566b9d2a4ab449d6bd555cb995421801"
+       ],
+       "layout": "IPY_MODEL_01eb22de4bd34c3fa21ed2a067e004d2"
+      }
+     },
+     "3bb9f4c97d7941ceae95734061e1ff95": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_8480f793680c4312b4c277a21ce133ff",
+        "IPY_MODEL_77b58009b00f450b9b8cd96242c97d0a",
+        "IPY_MODEL_d93ab3ad7f7a4b659eff51d6fae97725"
+       ],
+       "layout": "IPY_MODEL_72f8a7a6078e40ea914c8cbb16f5da92"
+      }
+     },
+     "3bc5c2cb4ff5438dac591481423be230": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3be771a783a24c9187fc4269b6e70b3d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_34f1af79616d4f0387793cb5ace7c634",
+       "max": 8755200,
+       "style": "IPY_MODEL_bc55081950e74871aa6dae7df9bb9e10",
+       "value": 8755200
+      }
+     },
+     "3bf7469f0dea4a728cb48a261e56ae45": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3bfcdcee28b34dd295476f09e97a04ba": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6353b0593d664057a040b5c626f8d340",
+       "style": "IPY_MODEL_3cd840b9539d4198b65634bd75cf83b6",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.qual_map.fits: "
+      }
+     },
+     "3c0878b98b6747ae825c0a290a7ff4e4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3c4eca840bc442f1805e82350607bc7a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3c50c2a35e3e424595d9b97e477d5f55": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3c5d43d5c9af4fe3aaa1728d82677d84": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3c96a321e39a45d8845a17f3a2928767": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3c9b1eaa3b684bca8a3eeaa195a6e92b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3ca92b3bb09e4732880c216ac1ecd62c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3cc6bb02a86f4e749f1a34e5e4a7c439": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_9a730f9a7e954c568d8c56e4186cd442",
+       "max": 9328320,
+       "style": "IPY_MODEL_0e484172246645b1aa0ecf6ce6695700",
+       "value": 9328320
+      }
+     },
+     "3cd840b9539d4198b65634bd75cf83b6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3d02fe05c87a41d5a0c4c0620b0706eb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_d4231f0cddda496e811cd18204b0a6e0",
+        "IPY_MODEL_e5fca260629a43eabae2f4438e65cbd0",
+        "IPY_MODEL_d9106af7d5354aabad00842e2ce68a6f"
+       ],
+       "layout": "IPY_MODEL_452b5b1e3b224aa29e54ec51a1b4ec79"
+      }
+     },
+     "3d0996a48efa4423a7b6afbcc0773081": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3d386fc334a44e4ea35fc9b25f73686c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_aac7683f9046428287280c9e081da758",
+       "style": "IPY_MODEL_490880f70da4403592a97d2a18d2dcd9",
+       "value": " 15.2M/? [00:28&lt;00:00, 1.25MB/s]"
+      }
+     },
+     "3d4e32535a0f4121815947c212378917": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3e00bd7c39fc41f29805797304c6a687": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3e2181d0bd7a4962ad16b9d110434905": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3e2995ca4c204192b30aba3770949458": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3e892982da6340fbb64edd4952e97e01": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_4fd65dabfaa64c3684151debd360cc43",
+       "max": 8997120,
+       "style": "IPY_MODEL_7bd1d59d30c54bf8872f22830d12e5ec",
+       "value": 8997120
+      }
+     },
+     "3ea999b89e0141b39ab7bdb1e48f9b0b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3ec15ec5113649e5975d62ee8c660ed4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3eeed23833a24bfaab4b20c2fe6776af": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3ef540c29c6f4f9e9bb27b4dcfc57af8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7a876e37bb73402fb709da8b2cc16368",
+       "style": "IPY_MODEL_0e68aeb970cc43b1af9778004177ad0e",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.azimuth_err.fits: "
+      }
+     },
+     "3f380b099e824632906dda2b8cf99f58": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3f385775175c42e4b934bcd2331522c4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_35238592a9a4459facee15eaf612cce5",
+       "style": "IPY_MODEL_3a841ed72d6046d08afbf84395f2ea15",
+       "value": " 9.20M/? [00:20&lt;00:00, 4.11MB/s]"
+      }
+     },
+     "3f851bb27d2e4bc6a2a4056d1591d8d9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3fa5cc1378c74fc9a76bd80a1165521f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_37dd56f7d0fb4e47aa4e23edfa96ae9b",
+        "IPY_MODEL_750f81195d14446592108e6c2b389511",
+        "IPY_MODEL_88bacd6af6dd47b595669ca82e43b18a"
+       ],
+       "layout": "IPY_MODEL_826039c2f9f7488ea597b3fa516b114b"
+      }
+     },
+     "3fb5cc946e0a4c41a69b30634255ae04": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "40275b8e48ba4f4f8801efe01667d066": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4028a7cde64c48b9b9cce39e86d13eca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d010657b84b44f188b241b741e6a10e9",
+       "style": "IPY_MODEL_801fd46aba3142dfbadc74efab6bb189",
+       "value": " 14.1M/? [00:17&lt;00:00, 7.79MB/s]"
+      }
+     },
+     "403b0a480a7348709b0c30b398473552": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4088e8893a074f33b771bb8a50d09b10": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "40c346b604d947f3ac078c05474a602e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "40c9fc5e76334aeebf97ed1ac4cc2fd6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a93f239cb99e4fd7b5e33e7f98fc5140",
+       "style": "IPY_MODEL_42e47071a2e74c2ab0e7805dffa9ab24",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.azimuth.fits: "
+      }
+     },
+     "40e0bf881b0b4e35b45f53430313f1ca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5720ce42322d4ee2804b4b7662947792",
+        "IPY_MODEL_a402b3454b97450bb564fb8cbca5ae65",
+        "IPY_MODEL_6a3ec6ee0c5747b88d022c116f3e779c"
+       ],
+       "layout": "IPY_MODEL_4db572daa7764111a2f3da925edaf178"
+      }
+     },
+     "40e7cbd7c44140c5b7005118d90c88f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4108d2b77b62451cabc7dc4dccc72872": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_ed5bd9a2c2da4cb786586791def2e023",
+        "IPY_MODEL_d904327e71734a48ac701f1e4a5e2e38",
+        "IPY_MODEL_85c21a598cd74fcfa207f4ba500084cc"
+       ],
+       "layout": "IPY_MODEL_c347b3217026453fbfcc5fb323c78945"
+      }
+     },
+     "4121115e52574db5851fc8e496fb6086": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4147c93baca1436eb64e942e16bedda5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "414f1bd78b144226bcda732b4bc42566": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b85b8d21b702496aa761e08ffae2eff4",
+       "style": "IPY_MODEL_f32a803be01a46f6bb9f9e4396f3aa83",
+       "value": " 395k/? [00:13&lt;00:00, 722kB/s]"
+      }
+     },
+     "4160af87c89341ecbc4b9737ae552411": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "416330dad12f45708af3875346bd7ca6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4168166c9d7241caa8ca2413b830c0f7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_db25c47f5814482e89340f143fe7c0f6",
+        "IPY_MODEL_8dcc0a14347a4cdaa4876bdc828f1fee",
+        "IPY_MODEL_218c3ce634bd4f8a83390523153480fd"
+       ],
+       "layout": "IPY_MODEL_f16c14d5ec9047598c147710fb066150"
+      }
+     },
+     "4170ded275bd45d79eb464485a2b8c39": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9aec7dc68dc4415589368327a4aace8d",
+       "style": "IPY_MODEL_704f31892041451bbc017112e6e827fd",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.inclination.fits: "
+      }
+     },
+     "4174cfe2c7504034a1d67059a566ec7a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_cb6344a214744440a9e1869c86f6dc3e",
+       "max": 24,
+       "style": "IPY_MODEL_e9fec1f6b5c54359838ec0e5928cb954",
+       "value": 24
+      }
+     },
+     "418f6f18a57c4376840d689462f1d9d4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "419666e5834c4871b3b9d19b200551cf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_378f26ac37ea4a9294d80f821d988843",
+       "style": "IPY_MODEL_6614f020ec8a4f00960e0487d87df63a",
+       "value": " 50/50 [01:34&lt;00:00, 10.74file/s]"
+      }
+     },
+     "41cb2fbd831c4c3d952617dc37ceeb06": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "41e2a698e0b2468587c1b16e2951258b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4232e52c2f834c259f1a31cea6bf3adc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_99a5820093894ee0b73ca3b554cbcfd1",
+       "style": "IPY_MODEL_5bf335fa8804472e9edd3ba50a5509e4",
+       "value": " 48/48 [01:15&lt;00:00,  8.82file/s]"
+      }
+     },
+     "4236c75016444603ba22aadc5a94b0be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_0ff9f991007942139036a197b87d696d",
+        "IPY_MODEL_231a8b0de70446808734ed1fc2f31f1f",
+        "IPY_MODEL_414f1bd78b144226bcda732b4bc42566"
+       ],
+       "layout": "IPY_MODEL_5ee3854fed244e6c9209fac7427b1e42"
+      }
+     },
+     "423dabad19414ad2bf8f1517dfc10201": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_72a235fbcd484866a23228c638b3dfab",
+       "max": 14932800,
+       "style": "IPY_MODEL_871179122e5e4daea1c2dfc19080d341",
+       "value": 14932800
+      }
+     },
+     "4247b8760c814e4ab2f61f3239f8305f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4258225aa33a4f2bbd0535444ced5cdf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "42a004c78cb14eb6ab5fb18b7eeb4f03": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "42bebe24770748898f012b4eaee400b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "42e47071a2e74c2ab0e7805dffa9ab24": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "42f8c9160cc54636a2037d873432aff9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bf42ab4455964fb79afdf1774e62b470",
+       "style": "IPY_MODEL_f7fd1412592c4e38bd4d09fa54b68de5",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I5.fits: "
+      }
+     },
+     "4313b14bf1f9425fa863998d6f37550b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "433534285fa94e5593b151deecdd4436": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_38e64350e4364720a24e8af129b97f9a",
+       "max": 50,
+       "style": "IPY_MODEL_941ef5a1e71e4a5597b15821f7536151",
+       "value": 50
+      }
+     },
+     "44327452ffcb4b70b489a8163e71492b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "44679fcb1e1d49fc8216d06ddf15b90d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_ee29022186d845bea048f38f671999f1",
+       "max": 48,
+       "style": "IPY_MODEL_39cfa600c5a64632b690f22d533d67ee",
+       "value": 48
+      }
+     },
+     "447a45ee29844867b57a1385ba583198": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "449de9ad6602447dab9a0614c2770249": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "44a69119f1854a04bb79dc3731352b61": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "44c337aef0354b618087f76fd1ecdbd1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_fe33faf6855c4bbabc9893df36dd2a1d",
+        "IPY_MODEL_24abd26f95e944f4a542da01587b3850",
+        "IPY_MODEL_f48864750f854b68a06ba213b5e4ade7"
+       ],
+       "layout": "IPY_MODEL_d7d09ec458fa4cc7ba0447ab9015df4c"
+      }
+     },
+     "44c33e195f704d13acdee5fdfdcec65c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4507e5cfbb2e43caa1a9cf310d5167c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_62696eddf2b7421ca6d37a164b920a49",
+       "style": "IPY_MODEL_416330dad12f45708af3875346bd7ca6",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I5.fits: "
+      }
+     },
+     "45177c218ce1457c9a969c319f148a96": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "452b5b1e3b224aa29e54ec51a1b4ec79": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4555f9a7e1e64ca9b31c9afb3f8ce457": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "457239935d834e8e80847d3fe99d473d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4170ded275bd45d79eb464485a2b8c39",
+        "IPY_MODEL_1a1d73cd62dd445cbbb83b681b7790a1",
+        "IPY_MODEL_c2e0e8d10f2148b1b079851bf77fb73a"
+       ],
+       "layout": "IPY_MODEL_40c346b604d947f3ac078c05474a602e"
+      }
+     },
+     "45a1eb77a73449a2ad9efb2b6451f09e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3c5d43d5c9af4fe3aaa1728d82677d84",
+       "style": "IPY_MODEL_2da4f9aa8491415089040f9cbca157e2",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I1.fits: "
+      }
+     },
+     "45ae75bd034340e8a978297089526676": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "45dc4b42ec454f70a67766f85bc65545": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "45e6b7a7c65b41d392a7b15f5cafe725": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "45e9cc01e8d44dac86e4c7c965525649": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_11a234b7c25542228be6fc5a4998ef6a",
+        "IPY_MODEL_03521c084fcf408bbcc492470d7a8adb",
+        "IPY_MODEL_8a3005742f9744a79d800c7c8022a49a"
+       ],
+       "layout": "IPY_MODEL_f170c67c5f674ade8c65ae64f4609b59"
+      }
+     },
+     "4601b367827a43f1a10e1a73ff8c92fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4604ef3b2f6d4add8549baeaf60ecc99": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "461ed12c491e4af6a23bcc240645a6f2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a80d8796d3d14639a36780916db9718b",
+       "style": "IPY_MODEL_2418437c5b654836bb15349014c1310c",
+       "value": " 12.2M/? [00:14&lt;00:00, 4.55MB/s]"
+      }
+     },
+     "46238d5080074debbebf2563a62b629f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e60366dbd7e84d5c9c943e1a585307bd",
+       "max": 8861760,
+       "style": "IPY_MODEL_113872e8dce84631b933b37bb34436c2",
+       "value": 8861760
+      }
+     },
+     "462b0d7d6bb545edb12b22e0fa8b1381": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b974c1b0d4f6467bab43e2f787c94977",
+       "style": "IPY_MODEL_c46c88160786440da4bc96806839e677",
+       "value": " 20.4M/? [00:19&lt;00:00, 9.16MB/s]"
+      }
+     },
+     "46a7302ea1824f2fb297d481241ee4f0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "46c2f6125a144ca2aa0ec815cd76069e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "46cab88e122a4ac3a99849b2d5539990": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "46deabc5f4144408985ec3f300301073": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "46f1c41ad7a44d49bdaaf2c590bfa279": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "470a3f84eb2a4a77a4e4a12f29386972": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4722c67ca57440ba937a4a4ef4b966ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "472fb97a20ad481db3d8ebcbf639e702": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "47618c2b4008462688e2618ca50375df": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "479507ca35f24b8eafca7c1890b24cef": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4797ac9ecca34ab7af3e7091ef7e6064": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "47bdd1c6b782451985f46ca042895bb3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8eb764b8f00e4b57b77df99e6bf338a9",
+       "max": 21836160,
+       "style": "IPY_MODEL_e8c60f2ec8a748aebdff4c8a8775e3b4",
+       "value": 21836160
+      }
+     },
+     "47c13051f2d2431a82909a151b3f250d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "47c83dc3f0f7429dac2cae5df2c5ce4b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4805fe6cedf0445eb10ee9ae8311cd61": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6048d9efb1d34f12bf13a7c49c0dbd83",
+       "style": "IPY_MODEL_cb5caa4e6e504013be4a74d62e95476b",
+       "value": " 9.73M/? [00:20&lt;00:00, 5.27MB/s]"
+      }
+     },
+     "483cb94e3d2b48589f7668cc161e2109": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_784a998ace4b4d6698fae3475edb6505",
+        "IPY_MODEL_c18cd1917e1842978a09825b4dcb71c0",
+        "IPY_MODEL_2593c4b5fb2241259e514a3f7aa162ea"
+       ],
+       "layout": "IPY_MODEL_49b564e911f5470a80c3d48d04464c45"
+      }
+     },
+     "484c3e46988b48fe815ba3cd2deb693c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4861aadc18f64cf1b51f6e208a5068f6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6881fbaa85ff4d799f830ceabc82a323",
+       "style": "IPY_MODEL_a47ba27da6804ca0af02151a2467d330",
+       "value": " 395k/? [00:14&lt;00:00, 749kB/s]"
+      }
+     },
+     "48a170bf4d0b40aa8f9197da3b1e3d99": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "48a49dcdf7b744cdac00d2784be19e79": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "48ae6b15da1649ee948d0157676d4a1c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f4f76b7170a6411ab823af9b960c749f",
+       "style": "IPY_MODEL_59678319048e4bc09513ea655e0e5706",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "490880f70da4403592a97d2a18d2dcd9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4936eeb40b934321aaf818ae7b270918": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2bacab27932143e8a0af4698f22ae857",
+       "style": "IPY_MODEL_f5de55cf665d4db9ab37946d838fea58",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "495a98995757407fbbabb99d69f98619": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "498e7a9767c7423e8550f1069ff982f8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "49a47110a4bf44c5b94bf2847409701a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8b10af0cc2164e9aa50c6a8900ea46bc",
+       "style": "IPY_MODEL_6961fa86f1ec4004b0540dec2fabacf0",
+       "value": " 9.34M/? [00:15&lt;00:00, 5.16MB/s]"
+      }
+     },
+     "49b564e911f5470a80c3d48d04464c45": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "49d2a267b1bf49e4a280de7b9648f7a0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "49e0adc0c842490bae773a6e1bbf364e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "49f2d310009a419a85d6bdeb0c540034": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4a178e64002a45c4a0b63aec687dc7c2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4a3e7147425e4714b6ee463daab4d257": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_86fe2ea3e0154a5796da376587cce562",
+        "IPY_MODEL_b3bb10cd9ceb4c4290f7b8b107f86ebe",
+        "IPY_MODEL_88e064602cc04495b619c298d347407a"
+       ],
+       "layout": "IPY_MODEL_b1fede81727e42ffaf20f874de0a8cc3"
+      }
+     },
+     "4a5ee02bac984a6087c1ae0194fe4c48": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2d65fcc1ccbe4c66af931fe0ef26e993",
+       "style": "IPY_MODEL_92810cfea42f4c3fbdf390a1e9b3f334",
+       "value": " 8.86M/? [00:27&lt;00:00, 1.70MB/s]"
+      }
+     },
+     "4a66192a1e7a41d9b00fabdd0a18f1bd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4ad1012fb3b04fd3a868589e1347686f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4aec1b914cd64e81854fb6fdc19ce47f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4aee07cef1354791999ba46df226938c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fe2bcb2317d64ad981608e1c4302d68c",
+       "style": "IPY_MODEL_10e1a6b1aaf44307a58b49f0066eee81",
+       "value": " 395k/? [00:18&lt;00:00, 545kB/s]"
+      }
+     },
+     "4af3103faaa749dfbca5348a6ebac21c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4afcc28d287a465ca95bc3a2c908d86b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_822422353e4647988bf28338571e82c9",
+       "style": "IPY_MODEL_196c2532e35d4c09a4498ddad3d03f23",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "4b118aefe05340b39e0a311ecb93aaa2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_742716ec3e254be3953ec94365eef864",
+       "max": 19647360,
+       "style": "IPY_MODEL_542b886af0744a1eaad36b61ff628403",
+       "value": 19647360
+      }
+     },
+     "4b5be9c7f6d641f1ba660cc81db7a1d8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4c31cf317a7d4805b379aab5f8cac4c9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f99b3076084f4fc8b22f4b4c6dbe85eb",
+       "style": "IPY_MODEL_8912279664e7403e9c3deb35492d9d7c",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.inclin_azimuth_err.fits: "
+      }
+     },
+     "4c65e3248c2c4ac38708f0897f8de8f5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4c88641547bb44079b4766083ffa391f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_75c535a6a11245aa9a4af21dae6682e6",
+        "IPY_MODEL_a1df4e1317204b57a0778d4cc6c6c32b",
+        "IPY_MODEL_cfcbba3b17f4478cb974717a3f639c56"
+       ],
+       "layout": "IPY_MODEL_1afae30a8bc04af781c8e852f3cc67ec"
+      }
+     },
+     "4ca861e6cf2d4f47b42090d26e7aa0a2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4cace2bca01c4dfb9587e05933ca7574": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_caa99c9da9424f40888aaa3a5b30fb48",
+        "IPY_MODEL_cc88a422ea204ddb97c4a6eeb78abcee",
+        "IPY_MODEL_940a892b40044269bb8daa5429eb8db8"
+       ],
+       "layout": "IPY_MODEL_e714b14ba4d9451f8b2c93fdd0e94ed5"
+      }
+     },
+     "4cc8b50a4e774aecbbc3c0dd59373473": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4d19370387184a68850288c282c03951": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_c7ea66fff7234ce7bfd010f24752b3ee",
+       "max": 19638720,
+       "style": "IPY_MODEL_6f0b8531b7f744eca1c480e747deb16e",
+       "value": 19638720
+      }
+     },
+     "4d320928138448f7aa24dd90b4e8397d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4d3b11cacec54d778a8627f2c2377cb8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4d450e7dbd084c0ca90cb5c18f2eb55c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_e3cacefdac604eb5843cb7649ce37a5e",
+        "IPY_MODEL_64aba7660dfd4fa496689f7fbc27201c",
+        "IPY_MODEL_adbf2dfcec4a4659994db46326d9ed98"
+       ],
+       "layout": "IPY_MODEL_0a50c5b7b98c485bb5ebb2764ed93bf1"
+      }
+     },
+     "4d6fe5f46afe407b96055c0bd9b31155": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4da3879b55a84491a9ee491369a56271": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_662faa405bed4829a69e77af31cafaef",
+       "max": 9711360,
+       "style": "IPY_MODEL_be56017028664290878f49bb62cf7213",
+       "value": 9711360
+      }
+     },
+     "4db4564dc79f47f0a006a0963929babb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4db572daa7764111a2f3da925edaf178": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4ddd2e526079473bbae908cf6c005abf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4de307f947f14a39b51080ffdc9fc675": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4e05d3c355f341dda5281c0e4a94e389": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4e745d4c80774f4989bf1defbd6d7147": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4e89b2be71ad4ceb831d93858df4b8f3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4ea10411e92d4ceb8427b5ff9cb92e4e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4ec9add2861b4dedabbe6ef46c4d5b6b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4ee85e9f209240fc8343f0a7be0c4593": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2f09e20eeea24877a72d79acf8c56bed",
+       "style": "IPY_MODEL_9e60600954344e27a72df2fc21bf7564",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.field_err.fits: "
+      }
+     },
+     "4efdaef95eec43c4b4835a2b36dacbc6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4f09d5d26cc9410d87dda392a88602da": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_28c1d8ca7ad044a2b52940640104e3a5",
+       "style": "IPY_MODEL_344c648329174fe88ca7f7c9d5482d1f",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.V0.fits: "
+      }
+     },
+     "4f217a7d684847da9f6b9e9639ba6fa7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_11e5e05ca86146a7adef2ffa3a254f19",
+       "style": "IPY_MODEL_1056c8fc12ac40bfa8121a15431cf789",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I4.fits: "
+      }
+     },
+     "4f9c4f5fc127417ab5d7142e9b89f029": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4fbb8059c22c45fcbd1af4e0d1f57a03": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_011d24cd26d64feba2efa30e975b7d0e",
+        "IPY_MODEL_b431dc53f0754c55af4da803cc42bfb9",
+        "IPY_MODEL_a77047921faa4a1a9bb3029c886ed527"
+       ],
+       "layout": "IPY_MODEL_dc9ef88cfda9498b9ea3b297bd7d2d2f"
+      }
+     },
+     "4fd65dabfaa64c3684151debd360cc43": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "501656aa60f54e13b179188b62dcfa46": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "50481fb42cdc4a7d8c693a0945df1fea": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "505ae17f5a7a42818475ee207945ef4b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5076ed9f7a5940008536dc666c373593": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5083041d6de54c3795c185f352f7767d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "50931d4bd23a404696535ad6da32fd9c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4f09d5d26cc9410d87dda392a88602da",
+        "IPY_MODEL_98f7ec3b32b64821878785af75bf5e37",
+        "IPY_MODEL_7074c142656b4a55a43ed98c79df3836"
+       ],
+       "layout": "IPY_MODEL_686cbad5aa164d83afd730eb54d12442"
+      }
+     },
+     "50b1e49e7fb942d18cc3da222aef7605": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "514beab8aeea464ba9627f14c17af77c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "51859dabb53d488e85f59901b1422129": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ac4f6fa3320d4d50ab86f88d921798c3",
+       "max": 8732160,
+       "style": "IPY_MODEL_74c8bdb75cdc4f7cbddc1aaab60a73a4",
+       "value": 8732160
+      }
+     },
+     "51b428845713473393e15d20af79b314": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "51fd94438216474cae8f7f9e39d7245d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "52443da88f63435eb1f1bfcfbcff962f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "52633550a961431e928d01bb39a9e823": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "528d7956ed644e0abac6023c19eb0ca4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5305ddde5d4b4bfdbd6ef2a978a4f2b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e4b390adf19047a895960768ff76280b",
+       "max": 14137920,
+       "style": "IPY_MODEL_bafc22e734ef44e48614d538399b4346",
+       "value": 14137920
+      }
+     },
+     "533e42b4d3db42a4b0137181008e4906": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c3f05fed3aa542a68a486bdd543e26ab",
+       "style": "IPY_MODEL_076ac9f53dfd4e1db5c07f024599dd0d",
+       "value": " 15.2M/? [00:22&lt;00:00, 8.22MB/s]"
+      }
+     },
+     "53429f131c3c47bb8b5fecfeaafe4efc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5357edc85c2547448380767c091848a1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "53a8c542279e42b4843ed20401ad9bcc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "53ece40b2920459487c06b82181ee11f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e6c3d4d45c5c420ba66badf44cd1aed5",
+       "style": "IPY_MODEL_57d496281af5450ebad615dfc36110cd",
+       "value": " 9.00M/? [00:13&lt;00:00, 7.30MB/s]"
+      }
+     },
+     "542b886af0744a1eaad36b61ff628403": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "54af2676878c43a483e4d7b819a2a608": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "54bc6ee425be4ed781e800d76d4568dc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "54e1e7ce932f4320b51b6d8eb80921e0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5502d0419d424edd968e637490b1f678": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "55465d7b2bb742418917eb21da77a069": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "556bf9195ae74fe2b96665ee61862dbb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5574a730745d46eea5325fedede34b91": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ea76ca29097a449aacb243b2bc89ce14",
+       "max": 9725760,
+       "style": "IPY_MODEL_01ab36817c274f8884de97303c1327be",
+       "value": 9725760
+      }
+     },
+     "55757874456941e7ab78a0fb61feaebb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_1e22acc0ee3941169a5f4bfedd8198dd",
+        "IPY_MODEL_fe17ab2c0bce4927ba59b7cd0b1a94a5",
+        "IPY_MODEL_19c3d709be834963894f48b5393ad120"
+       ],
+       "layout": "IPY_MODEL_7d9120db7d084aa0b0cba939c0063913"
+      }
+     },
+     "558b67fa6e3d46a999fc5dc9b48623d8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "558cc6e0c160457284bc4ecef5d81243": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "55ea70d56b9048f19e7185abb609e004": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8322be4fdc564b27b3afe23696051ac1",
+       "style": "IPY_MODEL_8f4f8dd77f3941b2b292e71e340ffd8c",
+       "value": " 9.34M/? [00:21&lt;00:00, 6.52MB/s]"
+      }
+     },
+     "56120591c2a84149abf7011f6c478a68": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "56173293c6c647548a6e217b2180243b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5657143ab2e34d2f915b37da2464af60": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "566b9d2a4ab449d6bd555cb995421801": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_62c9292bf0ea49d589057f6a323f4ef2",
+       "style": "IPY_MODEL_630c50938a8c46b89f7dec6e754a6fb2",
+       "value": " 45.0M/? [00:25&lt;00:00, 5.40MB/s]"
+      }
+     },
+     "566e0a0cb886460cb33831e8fc965a70": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5670c610c93a41c9a32c2b021853ffdd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "568ae6a1b5e94d1aa3d3c2ad0935db21": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c8441aee3f614443b0297c82baa1ad2d",
+        "IPY_MODEL_acac3ffb909b499a8db776028a0fa9e4",
+        "IPY_MODEL_04db521baf4d4cb2b9cf0e2d18c7d518"
+       ],
+       "layout": "IPY_MODEL_cb4b347c19cc4326b1a6aa455bdcce59"
+      }
+     },
+     "56d73412e67a4158b0fae1a5d1c2d896": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "56f2dfffd7aa43cea3a09bb4424d7cd6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ce287526464646ed8f367d37b97039e7",
+       "style": "IPY_MODEL_bfa85e9e2eac4da0aeea8992ddf4a15c",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.inclination_alpha_err.fits: "
+      }
+     },
+     "5720ce42322d4ee2804b4b7662947792": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_34823ceee9464590bb85d3678ec8153d",
+       "style": "IPY_MODEL_ad956c2384624c36b4eba5028b116863",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.U0.fits: "
+      }
+     },
+     "574f0c940df04a04b7036b2c83752ffb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9f6a7b3069ee42e6a15c1cae38ea8575",
+       "style": "IPY_MODEL_403b0a480a7348709b0c30b398473552",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.I4.fits: "
+      }
+     },
+     "5796bc0a403445e09bf6df5b20fc54fc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "57c3b03ad76e440fbb5f472969ae05dc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "57c8d6c891c9481d87cc2116c8b91fc5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "57d496281af5450ebad615dfc36110cd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5816ab5c744b4a08803ec73337467b17": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "584c83af5b6c467e9ce8c46c2365cd81": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b0eece8e1ae74efc9e06d33a8ecc6b37",
+       "style": "IPY_MODEL_a1ea4a9001b74c5c9ba4307a89835958",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.Q2.fits: "
+      }
+     },
+     "5868f343e2c04520884e4663ec82e247": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_006dc40de7b14a91b186f0645810e5a0",
+       "max": 9705600,
+       "style": "IPY_MODEL_f6eca701e8504d58ac7861f3eea6b53a",
+       "value": 9705600
+      }
+     },
+     "58c4257adf934b859cd6fda00471bd19": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "58d80fef179d4ecfbb77246664cca4ab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_3a95bc4b66c5441183991f76b511ea00",
+       "max": 15560640,
+       "style": "IPY_MODEL_b8c364178f704f9d9250f5ea81231344",
+       "value": 15560640
+      }
+     },
+     "58edbff70397452583fd8bf7600d31b3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5944f3c56d414491b411230fb11c109a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "594c0359c02946f19c287eda5cda0ecb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5952a072246343238e43d6f83e0c58c5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "59678319048e4bc09513ea655e0e5706": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "599cbc30dd524d488aabf73bcf5e0d92": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_9237e7efa8fb41b6b426527725b52d83",
+       "max": 12202560,
+       "style": "IPY_MODEL_4af3103faaa749dfbca5348a6ebac21c",
+       "value": 12202560
+      }
+     },
+     "59d4d3acf39a43959b5ff6f0107a5d12": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "59de1052fcce4fa5b3675b9b1d2a48e7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5a175b8c9776432ca5428779d88b7f59": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5a2874adfd7e493e814b46bf519c7b9b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_bdc45ce54ead456996692d131882de6b",
+       "max": 9731520,
+       "style": "IPY_MODEL_faafa999522e4cb3aa2c18fef0b32eaf",
+       "value": 9731520
+      }
+     },
+     "5a2a476cb9de4e55b92ad148356e9175": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_afd342b118a642fca04958e8b0a768d9",
+        "IPY_MODEL_081bf65d682e4f2f84e39553d5eb9401",
+        "IPY_MODEL_a4818710c435402c8c921a439f7f42ad"
+       ],
+       "layout": "IPY_MODEL_8cc7218380c642c9a6c77885741ddace"
+      }
+     },
+     "5a2fa5b5d56e4e9089a8294f681a00a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5a4cd27720184204babed64925b37d1b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_1968d23d17e54d36ae1bd9d56faa26f4",
+       "max": 9201600,
+       "style": "IPY_MODEL_55465d7b2bb742418917eb21da77a069",
+       "value": 9201600
+      }
+     },
+     "5a8b3835098d4cf1af6deb04f0049aca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_916ca57894f04ac489a8fc82bf1fec48",
+       "style": "IPY_MODEL_bb2a5f71a7fe42aea549fbdd7c4b2b93",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.src_grad.fits: "
+      }
+     },
+     "5aa7e14a7e824ca68fa161de0cb117e5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5ab65adefcb4413a97b0694b46cf3996": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_b0663dedee4e427bafbee9c4a2eba136",
+       "max": 8755200,
+       "style": "IPY_MODEL_0603eba9be524859bbcee2e6fd43e45f",
+       "value": 8755200
+      }
+     },
+     "5ad80ad5f59a48da95917c7b18c0d62c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_210b4e33a8f44c27a7cae77f5f645a5d",
+       "style": "IPY_MODEL_1b120fef0d004905858e738b0a4080bb",
+       "value": " 9.70M/? [00:13&lt;00:00, 4.61MB/s]"
+      }
+     },
+     "5ae14ae0c2e846eca6477b541771e8ec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_9f64e00bbf984f6694fccd837a4d7fde",
+        "IPY_MODEL_2bd220b575b84ea3a88490275adb2f7d",
+        "IPY_MODEL_77b8a3238ece4056976f905f034942d0"
+       ],
+       "layout": "IPY_MODEL_23d21f8913d343fd910f916b301f7a6a"
+      }
+     },
+     "5ae270136c324102a04b3911a5f45251": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b3fd59d1aeb412e8d723eead3ee1b9a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b57c805475a45e2934ee71eeba32b2c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_277f4f18d60d4c7eabfaafce23c765d3",
+        "IPY_MODEL_f609402455da4dfabf56ec3a54f6f2d3",
+        "IPY_MODEL_fd49461117f545e79fbb386ce1c80edf"
+       ],
+       "layout": "IPY_MODEL_a16d4862df5f4b26a33975d386a71a4a"
+      }
+     },
+     "5b5fc158585e4d63baddbba1e0e84f28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6a0fcbed7e774a3eb374c63cb23c61f6",
+       "style": "IPY_MODEL_28286b70a5cc48d5906e976103d7dd3b",
+       "value": " 24/24 [00:02&lt;00:00, 12.31file/s]"
+      }
+     },
+     "5b6b24350a824d6c92380e10fd19c6a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_fe292b51dfa14b0f9f05372fada173c7",
+       "max": 21856320,
+       "style": "IPY_MODEL_8234120ba36744a99e1b9832c604fb86",
+       "value": 21856320
+      }
+     },
+     "5b9672c123524dde9920d682c9c346d2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c8e9c9ff680340599f1c81d63654b302",
+        "IPY_MODEL_b74a5935dfab49c2a102ec00fb7f3334",
+        "IPY_MODEL_e87b4f0b9d8346bda5b144f22d92d27a"
+       ],
+       "layout": "IPY_MODEL_a87203de602c437aa0a93734c2c9476d"
+      }
+     },
+     "5b96e01b813242d8a12fe3a0e19b37d3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5ba020f2b3ff45a39a0c858fc3509e3a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ef8247d0ea414161822972c51d69f1d1",
+       "style": "IPY_MODEL_5d7b98571edc455ea2ff013ea85a0158",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.confid_map.fits: "
+      }
+     },
+     "5ba1a9ec894e4ca99757938d4a192d92": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5bba8fc24aa34853a74eab344e7f7c75": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d605ab6e4175446bb765c65a1ab05de1",
+       "style": "IPY_MODEL_975b03a7ac3b4a80ad5cd3a4665e0832",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.dop_width.fits: "
+      }
+     },
+     "5bc672aa0b53488a8294cfe043715bdb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_b0a23d2f849d409aa8cd566c93e1e7f1",
+       "max": 15157440,
+       "style": "IPY_MODEL_77dad1682d0a413b9a21dac6fe15d2e8",
+       "value": 15157440
+      }
+     },
+     "5bd25dc5cdec4c70836fa0e905e6ed53": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5bdd009fbffa4686831d2d02716b6d73": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5bf335fa8804472e9edd3ba50a5509e4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5bfaefc00b4e431bbc71ed1b121dd688": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_725613fd9fc24ba7b2f09335810cd8b2",
+        "IPY_MODEL_66025ebe485d4839b15908752013bdb1",
+        "IPY_MODEL_10ae22cbbad84951b576c68d5615d6c1"
+       ],
+       "layout": "IPY_MODEL_f07962247d15464589f9535c5461f71b"
+      }
+     },
+     "5c3746f019eb43a1b32318aa8618780e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5c3a69b51c44478ba9b2e5451e8c3e6a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5c3c32b8d9de4e899b9846a030ae5db0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a482a317f9894c7db5d48c8136f5bd1f",
+        "IPY_MODEL_20397dc97efa45f49939c35c99e8632e",
+        "IPY_MODEL_d7f1596cec634975b640029c58521884"
+       ],
+       "layout": "IPY_MODEL_884463b2346d41a4a450a941742ec072"
+      }
+     },
+     "5c76906109af463d9c47845fd0eef111": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5d07b7d0bf444d64aa3c0a292a8a7b28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_86fc91e619844a8f85cc24c8a9f6baeb",
+       "max": 19647360,
+       "style": "IPY_MODEL_775857ff7561472b872542effb98297f",
+       "value": 19647360
+      }
+     },
+     "5d2d4be8b61843ffbf51e5a74f16bb94": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5d7b98571edc455ea2ff013ea85a0158": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5d7c08fab6184fd39cd5c48fe47fe567": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5d826d34eec14d0994b6bb0ab855251a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5d8a58d207b74e119f2a2adbe80b71c5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_d2f82eca7f0742aaab9597d92e735049",
+        "IPY_MODEL_93d65c50827a4310855c0a963a12bd3c",
+        "IPY_MODEL_93150beaf16d4f2ca8435387df2cd857"
+       ],
+       "layout": "IPY_MODEL_3a4cb051f5d242b89758d0236c58d67b"
+      }
+     },
+     "5da5a6c0ff43423b9fc579cfe4c31959": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5da72991f2b444409ed64ad69951c717": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5e0dc425e1044f44bf4ec85c07e4ffec": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5e49534ce2bf48b0b4c561c7430ab05d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5e86048234cd46d7aa87e19be2131323": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_2516334319d448d798d24c1998aa4f0e",
+       "max": 8974080,
+       "style": "IPY_MODEL_0dbcfb6575ea4bceb2a4713f88105f4a",
+       "value": 8974080
+      }
+     },
+     "5eafe9863bea4bd198cb29c0c51366f3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9c6db8fde3514c45bf520c7b185d17a9",
+       "style": "IPY_MODEL_b79023ae8263443482cbf0b47f098f2b",
+       "value": " 21.5M/? [00:22&lt;00:00, 6.34MB/s]"
+      }
+     },
+     "5ece3df0e5714372a887b19e05d7344d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_66eba7e2031941f4aefd421a4ab1d0b7",
+        "IPY_MODEL_5e86048234cd46d7aa87e19be2131323",
+        "IPY_MODEL_dce4d80335f249ceb1d14774ab9bff59"
+       ],
+       "layout": "IPY_MODEL_b3b98b339595496f86768069bf21ea68"
+      }
+     },
+     "5ee3854fed244e6c9209fac7427b1e42": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5f076dafd14d452b856412b7b419267c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5f3e9587f5974b52abf991972397ac1e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5f6db6aa316d4ecfb133288c1d7d43af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_068ac3f4a84346c5b551a4c4852e1ccc",
+        "IPY_MODEL_74c0b4669bdc4e638bdd8f29bbd39db7",
+        "IPY_MODEL_38b9aa465200457b9943a5c660a347dc"
+       ],
+       "layout": "IPY_MODEL_bc31a351bf214865b2140e5b9ee22f8a"
+      }
+     },
+     "5fbf686ad511465786b1d6735b52c082": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5fc892d9e501409a992259c804d2b86e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_779b2293e8a44b41982be3f29b46cc0d",
+       "style": "IPY_MODEL_91a287a940d84f6b9008f38936a241af",
+       "value": " 14.1M/? [00:20&lt;00:00, 8.45MB/s]"
+      }
+     },
+     "5ff3a85335d44173abe18d69ed9b1e27": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "60212ec4dd854799afadcc2796487a46": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "604001a53c2b42b284666d3dc50023ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_3fb5cc946e0a4c41a69b30634255ae04",
+       "max": 9328320,
+       "style": "IPY_MODEL_aad2eb230c9f48878f70b91b0101e5a0",
+       "value": 9328320
+      }
+     },
+     "6048d9efb1d34f12bf13a7c49c0dbd83": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "605fbaaa7710446da7a1a3f01a1098c3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "60a034ccfab94716a0031401d79f9c55": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_bd75dcc69faf420ab60e9944644e6edc",
+        "IPY_MODEL_19318d5744e84a049289a0e8e15e32f9",
+        "IPY_MODEL_df738f2af4d74bba84bef585686e8d9e"
+       ],
+       "layout": "IPY_MODEL_1c2a10caecb745dbaf2edfd852ff7c9d"
+      }
+     },
+     "60d9e17c92f247aeacefaf8249b2e32f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6126fce3d25e4a7b90b4d79c2b922569": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_2cb3c7d1bded4d399b4664d472be4be9",
+       "max": 12179520,
+       "style": "IPY_MODEL_beb8c31ab55e4de4bdcb61ad11e2dd13",
+       "value": 12179520
+      }
+     },
+     "6138d801259b440b9e32e9f1c6d3651d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_3ca92b3bb09e4732880c216ac1ecd62c",
+       "max": 21530880,
+       "style": "IPY_MODEL_88e377dfc31e494c8c4951b575f3e2cd",
+       "value": 21530880
+      }
+     },
+     "6146c84188b64073932120cb84693466": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "61b45e83622645e8b15ed662076748f0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f31e54bd3ca44efd98890eeda9b213a9",
+       "style": "IPY_MODEL_e4c2cb82ff5d4cdaae83cca7419466b9",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U0.fits: "
+      }
+     },
+     "62696eddf2b7421ca6d37a164b920a49": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6275a4ae4442496f8711bd5bbd7cd50f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6286c62d97a047cfb30ddd6494c9bfe5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "62924c4aff014faf9eee8219bb26e10e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "629f95ec78be4f2a97e8681ee1efe70b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "62a3f8ef40164644ad72cf479e2e15e1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "62c9292bf0ea49d589057f6a323f4ef2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "62dbb41e6d31423b99fcaa638a71d1b6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "62eea98c287e4cdd99be8f1f544805c9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_33eda21075ed495b964568977a512d97",
+       "style": "IPY_MODEL_745557f8b3504f809e2f7a18ce68e8af",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "6304e7b058684cd8a946af2a037d51ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "630c50938a8c46b89f7dec6e754a6fb2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "630e4d46f7c84acf8fc9f12b4ccd901a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6343dd8d14d7476b9eab384b72f29b59": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6353b0593d664057a040b5c626f8d340": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "635f360e0e5b4fc58fb11dcf891f7fdc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_0bcf902ee988452ca632e6326ddb9321",
+       "max": 25,
+       "style": "IPY_MODEL_80c4b7b3b18848408a27d793507cb4ac",
+       "value": 25
+      }
+     },
+     "6360ac67976547a7b99992c16a3b71a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "636d19802c0c4224a454358325e3eca8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "63809399673842b3beaefa4a05f1a0b1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ccb9eaf17e554cf89071ab96cd0bf24f",
+       "style": "IPY_MODEL_886b6de1f2e442f2bae536e3c94cba66",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U5.fits: "
+      }
+     },
+     "639891ede6b540748a2f55904bfc54c1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "63b0b93773f24ccc92bf090cd443fc1d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_92affbdc0a6746c7b3342854f8b91aa4",
+       "style": "IPY_MODEL_184ba17c3b434a039c1e663c4ec36236",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.eta_0.fits: "
+      }
+     },
+     "63d72e7c3c154e46b7a1bdda48122718": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_71b556e1ba4c4d569d8b4a4da11de698",
+       "max": 15163200,
+       "style": "IPY_MODEL_9379565d0f3344719a0c7e9d21d097be",
+       "value": 15163200
+      }
+     },
+     "63dec9c05ae14aa9ba88922436217008": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "63ed1eab46b84d368286c581aca93b0c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4b5be9c7f6d641f1ba660cc81db7a1d8",
+       "style": "IPY_MODEL_08c82b67428b413ba07547d5be31bc74",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "6414119f4aea4978a05026ad135a1229": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "642a32369e49423e9ee02772d9d510fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "644359e259e14cf682afa06ce8f52c25": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6455ffb778974bfaaa0c199c41d64bae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c14b44a6afaf4bb4ac41022ee46eb448",
+       "style": "IPY_MODEL_73814837b9fb478c9a9de462fef453db",
+       "value": " 9.57M/? [00:18&lt;00:00, 5.70MB/s]"
+      }
+     },
+     "6463de8ee03d4e8dbdb5be349b370103": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_605fbaaa7710446da7a1a3f01a1098c3",
+       "style": "IPY_MODEL_d0919fa18f4b49378d60c28b8cdb3173",
+       "value": " 9.57M/? [00:12&lt;00:00, 7.01MB/s]"
+      }
+     },
+     "64663e876896424a9da23987039ea616": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6472a0d99d9d4e81b8c25f1da338c251": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "648a9e9ee55246d7878c0b55594bd5b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "64aba7660dfd4fa496689f7fbc27201c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_81af68b909f04e08aa9d7c7f9f4b1e30",
+       "max": 20450880,
+       "style": "IPY_MODEL_f65c15315a574e3cbcc84ef25ace5700",
+       "value": 20450880
+      }
+     },
+     "64d1b3e9991747388feb7a33fdf1b707": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "64e1aa77bc2648e994a993d432bc5190": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "651a0c9e0bf748d6abd1bfca56501134": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7c6e7bac493b4066a6a006bd57d65063",
+       "style": "IPY_MODEL_c5636ee83ef34880a9676b038d230fe9",
+       "value": " 9.00M/? [00:21&lt;00:00, 6.91MB/s]"
+      }
+     },
+     "651f8e9f80304814accf8290a0bf30b6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "652ee9b40ce746b38c48c115c4af9684": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "65413e2d90364853b7aa3341896e8d5d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6551920c57c74a9598dd518b675a1519": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "657c153a22ad4ae1bfdf131c04065d3f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "65a11191a9034622a52f327f6096ef51": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "65b55d38d897452c8fcc28affdde5393": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c5a4fff3e6ba4673acb4d45a7d831934",
+        "IPY_MODEL_635f360e0e5b4fc58fb11dcf891f7fdc",
+        "IPY_MODEL_1d2f035313014b6a825b151b78b975eb"
+       ],
+       "layout": "IPY_MODEL_94f631572bb64045948413a6d2b473a5"
+      }
+     },
+     "66025ebe485d4839b15908752013bdb1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_0a8f2343bb9e4f65b7110067b57d2b5c",
+       "max": 21836160,
+       "style": "IPY_MODEL_2e3dbd9fcd6b44e3a88070887219c9e0",
+       "value": 21836160
+      }
+     },
+     "6614f020ec8a4f00960e0487d87df63a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "662faa405bed4829a69e77af31cafaef": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "666dc583f77749a99c345111a3e821b0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6693492dbec74354a39ec646eb826ff9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "66bf071007cb4826b84767c98269c769": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_74bfeb3173bf4abfb1e688dfc89b7e36",
+       "style": "IPY_MODEL_6275a4ae4442496f8711bd5bbd7cd50f",
+       "value": " 14.9M/? [00:20&lt;00:00, 4.32MB/s]"
+      }
+     },
+     "66eba7e2031941f4aefd421a4ab1d0b7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d252d15f1fee40a2a85506f04bf88997",
+       "style": "IPY_MODEL_3c9b1eaa3b684bca8a3eeaa195a6e92b",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.V1.fits: "
+      }
+     },
+     "67104e6656f94d1f82e8c702972fafce": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_76070b25de9242ba986bffe4fcf502a9",
+        "IPY_MODEL_ef7fa6c609454c1f828e19f3aa4a2747",
+        "IPY_MODEL_8bdfd4f2d556485da0a0942b958a6f47"
+       ],
+       "layout": "IPY_MODEL_7b7835fea08c485587b218f6a632b5d8"
+      }
+     },
+     "67148bf5df5c4d2a8d4267ffa090aa97": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "672240362d91489a8c61a539cf39825e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "673995d7fa424a3188bf7565c0a0c757": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c2b7aba8f150401a8b422f8a11e6a709",
+        "IPY_MODEL_d96a1786a94647a8aba6635fc6f8c7a5",
+        "IPY_MODEL_20b6ac165d144aacb83d2a7b6983663d"
+       ],
+       "layout": "IPY_MODEL_64663e876896424a9da23987039ea616"
+      }
+     },
+     "6746338fda9c4c01b59e4c1623d5ae71": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "67c72c7231114327811b5dc7d4967015": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "68139d2f9ab14ce8842c5b715c7fbdad": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "681db60066ab4623b50631c64b9fb997": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_94f100d363a844928aa912ced7b66bd2",
+       "style": "IPY_MODEL_ae3b1810b8c34b009bcf2a51817f3bb2",
+       "value": " 12.2M/? [00:22&lt;00:00, 7.50MB/s]"
+      }
+     },
+     "686058f6288d429596802be2367f5225": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "686cbad5aa164d83afd730eb54d12442": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "687d69ea55f04cd0b81098568587f822": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6881fbaa85ff4d799f830ceabc82a323": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "689373b9e9e24c3687a48d15c19aa4fe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "68b83e5ecef74be79237fecb4c23ed30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6908060df2604a2eab16d637e3ce67e7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6913fba89c8643ba9f0f8b1c56046dfd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6961fa86f1ec4004b0540dec2fabacf0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6977da333aa64b6a86b4dfec53d4db77": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_2f59911de876440f82b7ccfa2d5a739d",
+       "max": 15163200,
+       "style": "IPY_MODEL_de80115f4941403c9882121bed01be39",
+       "value": 15163200
+      }
+     },
+     "699a45074bc64149be7c819aca12af86": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "69c385fd0c724585a5ddacff8218bfdc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "69ff1941cf7b4a6f9daaa583ce9b7335": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6a0fcbed7e774a3eb374c63cb23c61f6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6a3ec6ee0c5747b88d022c116f3e779c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cca6cd31aa214c5f9a4197f32abd8846",
+       "style": "IPY_MODEL_d4d1931f7f404067ba916e7c28bebcb0",
+       "value": " 9.70M/? [00:20&lt;00:00, 6.99MB/s]"
+      }
+     },
+     "6a79b845527c42cd9d9af02b44dcc086": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_85c820892b6a445ba1ede0274dd8b8c3",
+       "style": "IPY_MODEL_824f00d74ef7497399f37c5adfe044a2",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.alpha_err.fits: "
+      }
+     },
+     "6a84bcf3c84743b6b771a83e3ff0d2b6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6a8767cc08154aacac772e11598ecbbd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6aea4578c4a2453684b58802fe7663ab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a813c097b4e749aa89afb6aa0912ef0c",
+       "style": "IPY_MODEL_bcd8580769e347c1aad68cbeb4380ec0",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V4.fits: "
+      }
+     },
+     "6af10cfa36b848eaaeb60a137dd109b1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6b22d4db3349479fa891021ba3d94066": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6b2ac75139d1400693076d7163e574b0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7bfe222bed904517910ce63fa77b4bd4",
+       "style": "IPY_MODEL_4cc8b50a4e774aecbbc3c0dd59373473",
+       "value": " 14.8M/? [00:23&lt;00:00, 6.03MB/s]"
+      }
+     },
+     "6b30edd5e66847bda93d0e76128f8f8f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6b6597fe31db4b35a9c3d22112bf952f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_aa432630e8da4f0ca166463c68696591",
+       "style": "IPY_MODEL_ad359fe9fa31469c865c15951ce76f1c",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.azimuth_alpha_err.fits: "
+      }
+     },
+     "6b9f0bf33bb14218b6d6d187a6bd6dab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_447a45ee29844867b57a1385ba583198",
+       "style": "IPY_MODEL_f2ca1e6fae5040428061faef214ab11e",
+       "value": " 8.73M/? [00:19&lt;00:00, 7.26MB/s]"
+      }
+     },
+     "6bce8e13c0494a0e8b39d758b59327b9": {
       "model_module": "jupyter-matplotlib",
       "model_module_version": "^0.9.0",
       "model_name": "ToolbarModel",
       "state": {
-       "layout": "IPY_MODEL_a99f1ed5dd9d49c18cae00cc9cd49bab",
+       "layout": "IPY_MODEL_033e523f8e63405f88585dc216d78f87",
        "toolitems": [
         [
          "Home",
@@ -648,7 +7594,4418 @@
        ]
       }
      },
-     "a88340737959479bb487bb477c08f14b": {
+     "6bf3590b39214e4aad411975f706f2b0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6bf8b6a02ec8444aaa9779114c92b1e3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6c925084b55641deb723456de8ee666c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6c975854b0ae48819c62ab64152f82f3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6cbfa6bf60b341b68348fa60e7e40f29": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_574f0c940df04a04b7036b2c83752ffb",
+        "IPY_MODEL_b2d03115cb7642619284cdcd0207bf9c",
+        "IPY_MODEL_0778870ccae144c9bb789214d620a2b4"
+       ],
+       "layout": "IPY_MODEL_1590a40751d645adb8a0a2f58bc2f4b0"
+      }
+     },
+     "6d1ab58a8e3e431c8fd772358242686a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6d2883f17a2e4ba4a4867066aa5d680a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6d3342687943449798b3f906bae60956": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_1ded27e7190f425992b8c0ae1def106f",
+        "IPY_MODEL_ab4085600e964bbebd436e6985c35dcd",
+        "IPY_MODEL_109d724c1e6941348594cb39dacd8397"
+       ],
+       "layout": "IPY_MODEL_f656f2a9652741adba466c7fd4d4c5f0"
+      }
+     },
+     "6d7dbd1be80249d9ba131adb7b67a539": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6d8523c1ecba44be8c3b6dba15ae2a0c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c14bd93f44ce46e284a3f60ec0e7861f",
+       "style": "IPY_MODEL_14ce98576c5a4c2aa68aa32feff1f7bb",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.damping.fits: "
+      }
+     },
+     "6d89289c453d49188c0e7d4c58a050f9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6da1a356c8aa486fbde7973a823e20d5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6db70168c4604ac2bc4026c91b564536": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6dbd775a355b44f0b78bf747a72a85cf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6df650fc59f04d0db42819ca97b49e4c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_04d1ecece69b43d686bcddf2f8a4f5b8",
+        "IPY_MODEL_5305ddde5d4b4bfdbd6ef2a978a4f2b4",
+        "IPY_MODEL_5fc892d9e501409a992259c804d2b86e"
+       ],
+       "layout": "IPY_MODEL_6146c84188b64073932120cb84693466"
+      }
+     },
+     "6e0340a0e3b64a09866e61eb883e861e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_a6570fcb2588438ca77a620411e34254",
+       "max": 48,
+       "style": "IPY_MODEL_78894bb0701f480b82a54b9cac847d6e",
+       "value": 48
+      }
+     },
+     "6e1b195b77a1455e91630496cd94951e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6e5d5d1391f54fb893ee4df2eab2fb5c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6e8b2edc87a0488f976654f24367d09f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6eb28e66fe854964bab2a22bfefcfe4a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6eb85c96bd9d40e390547fcea3e59f2d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_472fb97a20ad481db3d8ebcbf639e702",
+       "style": "IPY_MODEL_3aee5124438d42a9aff85a1c67fb8624",
+       "value": " 14.8M/? [00:19&lt;00:00, 4.39MB/s]"
+      }
+     },
+     "6ec1231c84dc45e5ba392a9910ed73e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6edfb814ddbd41fa805e7b18803b00aa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6ef7b8f082e047b9a4b0014ae8fe0a5f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6efb7360717f4077abc4445abc43ade2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6f0b8531b7f744eca1c480e747deb16e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6fac291596bc4763b676abe0a1879baf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_777530a0516743dd972dd50fc88ab54e",
+        "IPY_MODEL_8233ebe494444cfd9230191a13e426c9",
+        "IPY_MODEL_9050dbbee1b945858d16defeb166606a"
+       ],
+       "layout": "IPY_MODEL_b72c267132904193b0c41fb39804ecd8"
+      }
+     },
+     "6fb3ebdc75784e7ab6af11e45ee2a823": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3a442cfce2454bf28e916ca0a6cfe953",
+       "style": "IPY_MODEL_b02251a0a4ca404c9ee411d35c822d2e",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.field_alpha_err.fits: "
+      }
+     },
+     "6fbc03ec8db34a4f8940b41654f2901e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c5159c8f64ae452ebfbcb2261744c476",
+       "style": "IPY_MODEL_4f9c4f5fc127417ab5d7142e9b89f029",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "6fc7d02e92444a7b94702f085d4f192e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_6e5d5d1391f54fb893ee4df2eab2fb5c",
+       "max": 9336960,
+       "style": "IPY_MODEL_bd5f247686e44f028d70f6b200ff265e",
+       "value": 9336960
+      }
+     },
+     "704603a340c94ee28d74b31fcd449b3c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_07fac29b68894d128ecd476530cf9c0f",
+       "style": "IPY_MODEL_8cd651cd755d49c5ac2a2b9a4a978f77",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q5.fits: "
+      }
+     },
+     "7048be659d934bfcab2f0d0127da1c64": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a4ba7d5ff4f5480385c8b347dfcb762b",
+       "style": "IPY_MODEL_1f3f6343740d4dd2a06fad474afc17dd",
+       "value": " 395k/? [00:17&lt;00:00, 663kB/s]"
+      }
+     },
+     "704b139e08034185b4c43fb743566fed": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "704c724db1154475bb4b5d78150ad086": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_639891ede6b540748a2f55904bfc54c1",
+       "style": "IPY_MODEL_47c13051f2d2431a82909a151b3f250d",
+       "value": " 1.35M/? [00:17&lt;00:00, 1.93MB/s]"
+      }
+     },
+     "704f31892041451bbc017112e6e827fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7072490ff38940aa98e9deee8e7cdf8c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_dbe96a3c216a49c9b6a6c4e81fcc516a",
+       "style": "IPY_MODEL_63dec9c05ae14aa9ba88922436217008",
+       "value": " 2.90M/? [00:20&lt;00:00, 1.56MB/s]"
+      }
+     },
+     "7074c142656b4a55a43ed98c79df3836": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fec9c70af7e14c2da13d9cac77723890",
+       "style": "IPY_MODEL_cdff8f2483e2470dbca94cf5c00c7956",
+       "value": " 9.01M/? [00:17&lt;00:00, 3.75MB/s]"
+      }
+     },
+     "70960a6b97d946ddad2a0fc707dc9543": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d213a2f7ef7d4698b360068e27ae9655",
+       "style": "IPY_MODEL_652ee9b40ce746b38c48c115c4af9684",
+       "value": " 25/25 [00:02&lt;00:00, 12.57file/s]"
+      }
+     },
+     "714a67c438284ce48f7c1bc37655ea07": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "718ab802c6ff4f4a88b09a9726bf86fe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5a8b3835098d4cf1af6deb04f0049aca",
+        "IPY_MODEL_b65fcff52bdc433a8175fdf4fd582f95",
+        "IPY_MODEL_1d13ce6c2e634d65a51dcb175562be8c"
+       ],
+       "layout": "IPY_MODEL_75b526a0ecbf4d2da109c092959646c5"
+      }
+     },
+     "719912dee930419ab266150e6db7130e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "71a4075e7bbc4b22b01e93b6165203f8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ba540adcce964ab4ac71b7550339cc3d",
+       "style": "IPY_MODEL_013114be289e4d10941a160b5878f7f9",
+       "value": " 19.6M/? [00:23&lt;00:00, 7.93MB/s]"
+      }
+     },
+     "71b556e1ba4c4d569d8b4a4da11de698": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "71f4c85b2db54b0c90d2e9797040335a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_46c2f6125a144ca2aa0ec815cd76069e",
+       "style": "IPY_MODEL_0c9aac6f7d53436fb7986e19b2b65ddd",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q0.fits: "
+      }
+     },
+     "71faae84ad71461dab717cda40540a32": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "722b0429a64e4e13a754f015404d4050": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "722f00bf361743c9be237e1097fda2f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "724ab035499b4bbdb7b264ebd6fb29d8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "724b2abe4b4a4b3690aa83ce95705a75": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "725613fd9fc24ba7b2f09335810cd8b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6a8767cc08154aacac772e11598ecbbd",
+       "style": "IPY_MODEL_44a69119f1854a04bb79dc3731352b61",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.chisq.fits: "
+      }
+     },
+     "728d6fa2fa5546d18bed2a3c13f763de": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "72a235fbcd484866a23228c638b3dfab": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "72aa1c083f054177b1548da0939a8138": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_56173293c6c647548a6e217b2180243b",
+       "style": "IPY_MODEL_734816cf93084ad9af77a694debcba48",
+       "value": " 9.71M/? [00:24&lt;00:00, 2.38MB/s]"
+      }
+     },
+     "72b379dc310543958d0b4384f1658bba": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "72f56eab172d4b0bb21a14633121975a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_bc540e8ccb3d42a89dd566fad7030285",
+        "IPY_MODEL_1f209d6d98e548a2804d6f0baef128f3",
+        "IPY_MODEL_258aaec2fb8d4b46a019a6b4bb05538d"
+       ],
+       "layout": "IPY_MODEL_5ba1a9ec894e4ca99757938d4a192d92"
+      }
+     },
+     "72f8a7a6078e40ea914c8cbb16f5da92": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "732060790b094e99a1eda3483fc0f952": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2698ad785bdd4ee5bd1fb6cac782e8db",
+       "style": "IPY_MODEL_99c16436ad2142c2a40086ad23834baf",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "732caedc944842bd90aaef3c2eca44c3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "734816cf93084ad9af77a694debcba48": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7356fe16f718447485b055f4d3890048": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c9d52df11f964fdaa8a0bfa482dec496",
+       "style": "IPY_MODEL_1e601f9283564f61a76971c1a0fb7e9d",
+       "value": " 45.0M/? [00:20&lt;00:00, 4.22MB/s]"
+      }
+     },
+     "736945394f5c45819a69c3c8b07bd528": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "73795a2c7bf245b9a5cffdaed325b63f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "73814837b9fb478c9a9de462fef453db": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7387bfcba7ad4525929c32d3fb4fbcf0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "73e3e29c13744404b9f9ef8d15110d0a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "742716ec3e254be3953ec94365eef864": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "742d63f2e241488baacf2e5da00518ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "744a8d44d14c4f48a6b9d32a051a3727": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7450e8093ba54a44a04ee2e5c095afca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "745557f8b3504f809e2f7a18ce68e8af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "74a0953308c04152b2b0c2519469855f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b8a1170351314ad9900eae6e43696ac4",
+        "IPY_MODEL_7cf6828e1cae4249931a95466aa013d8",
+        "IPY_MODEL_419666e5834c4871b3b9d19b200551cf"
+       ],
+       "layout": "IPY_MODEL_ea0f0d871665451da06ea1443cde404b"
+      }
+     },
+     "74a14f1c7fe74d059528e95e12c51ea6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "74bfeb3173bf4abfb1e688dfc89b7e36": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "74c0b4669bdc4e638bdd8f29bbd39db7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_cafb05d96ebc48ff9dbe0e7b5bbdd56c",
+       "max": 24,
+       "style": "IPY_MODEL_57c8d6c891c9481d87cc2116c8b91fc5",
+       "value": 24
+      }
+     },
+     "74c8bdb75cdc4f7cbddc1aaab60a73a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "74efcef938c448888d36d509457c086e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "750f81195d14446592108e6c2b389511": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ea451995146d4f80a7a74be9653c69be",
+       "max": 16064640,
+       "style": "IPY_MODEL_06563c6aed64481abfeb2b2b6745fe36",
+       "value": 16064640
+      }
+     },
+     "7522fe90cdfd4f75bd2af6c105153e5d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7528bc11af07422cbf99afb1d7f74921": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6a79b845527c42cd9d9af02b44dcc086",
+        "IPY_MODEL_38867bdd98f9438e9f2620c0a9c9a849",
+        "IPY_MODEL_b240288545124299bfa2d3b18e7e7c78"
+       ],
+       "layout": "IPY_MODEL_263b9b14310d4e52b14d20d53e9d3aa0"
+      }
+     },
+     "75996e6d488a4834bb67962b6d3dc64d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_12c655f93943482dba7429623bdff0df",
+        "IPY_MODEL_20010c3944c440ca8aee4721d37279bb",
+        "IPY_MODEL_c0c51168bc77491ab87cbbf7d02c6cb3"
+       ],
+       "layout": "IPY_MODEL_097cbb94ead24691a7b7c3e5db12e6fb"
+      }
+     },
+     "75b526a0ecbf4d2da109c092959646c5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "75c535a6a11245aa9a4af21dae6682e6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d1004b8aea7c437b83647b1468f47f4f",
+       "style": "IPY_MODEL_0fd0ca8ef88444ff89870ee791664c3e",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.Q4.fits: "
+      }
+     },
+     "75f1329fb71e4f9d9cc380dfca0fb935": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "76070b25de9242ba986bffe4fcf502a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4d3b11cacec54d778a8627f2c2377cb8",
+       "style": "IPY_MODEL_ec3e0fcd0eab4cfb8e405d0083146afe",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field_alpha_err.fits: "
+      }
+     },
+     "764c91d2eb84479aa15a089f43cc9895": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "771e9669f8274633a0f165407ac64b0d": {
+      "model_module": "jupyter-matplotlib",
+      "model_module_version": "^0.9.0",
+      "model_name": "ToolbarModel",
+      "state": {
+       "layout": "IPY_MODEL_505ae17f5a7a42818475ee207945ef4b",
+       "toolitems": [
+        [
+         "Home",
+         "Reset original view",
+         "home",
+         "home"
+        ],
+        [
+         "Back",
+         "Back to previous view",
+         "arrow-left",
+         "back"
+        ],
+        [
+         "Forward",
+         "Forward to next view",
+         "arrow-right",
+         "forward"
+        ],
+        [
+         "Pan",
+         "Left button pans, Right button zooms\nx/y fixes axis, CTRL fixes aspect",
+         "arrows",
+         "pan"
+        ],
+        [
+         "Zoom",
+         "Zoom to rectangle\nx/y fixes axis, CTRL fixes aspect",
+         "square-o",
+         "zoom"
+        ],
+        [
+         "Download",
+         "Download plot",
+         "floppy-o",
+         "save_figure"
+        ]
+       ]
+      }
+     },
+     "775857ff7561472b872542effb98297f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "77630769ecc84653983b05ed096395ec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "777530a0516743dd972dd50fc88ab54e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a6a4a7f78cf9410ca9b924e0e44eb28e",
+       "style": "IPY_MODEL_4efdaef95eec43c4b4835a2b36dacbc6",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field_alpha_err.fits: "
+      }
+     },
+     "779b2293e8a44b41982be3f29b46cc0d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "77b58009b00f450b9b8cd96242c97d0a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_d7434f40ca564493b23068c47e1a834e",
+       "max": 9550080,
+       "style": "IPY_MODEL_fc47112281984dad8c5649ffe6adbf28",
+       "value": 9550080
+      }
+     },
+     "77b8a3238ece4056976f905f034942d0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2e3d73f2aedd41f38756b24c313fc557",
+       "style": "IPY_MODEL_e2bd0bf60c034589b9783d759649ea9e",
+       "value": " 15.2M/? [00:15&lt;00:00, 4.59MB/s]"
+      }
+     },
+     "77dad1682d0a413b9a21dac6fe15d2e8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "77ebe9a871de4b58aa6224bfd29c94c2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "78015fbdc07a4d82b56a8d0b0fc3714d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "784a998ace4b4d6698fae3475edb6505": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d77272f74cba4e0aaca5a804d59c352d",
+       "style": "IPY_MODEL_64d1b3e9991747388feb7a33fdf1b707",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V1.fits: "
+      }
+     },
+     "7880ee4fcac24e8bab260ef437978abd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "78894bb0701f480b82a54b9cac847d6e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "78b32e3b2c9b46adb98b3a5f7d18ba59": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "79068570764547c3b1a3ea472d62df72": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "793e41db359247699563aabfd9404396": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_0bc87388af5b4420b1a04f862c525c41",
+       "max": 9336960,
+       "style": "IPY_MODEL_05ce757b91e04510984183439ce06439",
+       "value": 9336960
+      }
+     },
+     "79734988edf6481ab4c9db56a3c2eb14": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8c246ae312974b028dfb765bd9cca3eb",
+       "max": 10402560,
+       "style": "IPY_MODEL_8fed72b027f94671a1c2cd0a1af80337",
+       "value": 10402560
+      }
+     },
+     "79783f393fee44489b748dcaa74f4cac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "79a1144fb1e748a6bafa118c3c9f3504": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4d6fe5f46afe407b96055c0bd9b31155",
+       "style": "IPY_MODEL_e0167755e2004576b359a792eea80619",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I0.fits: "
+      }
+     },
+     "79cc6511a68f427a82bd78d3a9d66b58": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7a1e025d792d46e18681673d7e2258a3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7a75343a1d1d484eb2e3067517b5a4ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7a7b05cdfb5245e79536ac9921558133": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_9b607b0e21524c02a8937955881991b7",
+        "IPY_MODEL_a019ad7e38244e31a667c1ed7710573b",
+        "IPY_MODEL_e044d9c82a9a4867919d5fb421915022"
+       ],
+       "layout": "IPY_MODEL_cecc4ebe600a43a798b9fc3147034c93"
+      }
+     },
+     "7a876e37bb73402fb709da8b2cc16368": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7ac713c4f0424c628f7b05f043497753": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7ad6fae7ac344fccb575322bd623c616": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b23425a269044caa623ff03027deecb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b45b9c03ac44ae09a636056dc7eb65d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b602a1cc2a84614816ba50b2b6804de": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b619b9c29224736a52ac05645f4bbfe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7b7835fea08c485587b218f6a632b5d8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b94a99a5d174acaba530f1cd0d25784": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7bce329f6e904c9596fa8f973a1c6d41": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fb3798ad7bd941db97aa4f0bf480c753",
+       "style": "IPY_MODEL_24fe5af80b3c4bb8a6f0c52f9f89383d",
+       "value": " 15.2M/? [00:16&lt;00:00, 8.36MB/s]"
+      }
+     },
+     "7bd1608b64ee4449bc11087e3b111698": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7bd1d59d30c54bf8872f22830d12e5ec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7bfe222bed904517910ce63fa77b4bd4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7c2f3c6e0e454d63976f817541765e2f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_03c55e1fb54d4a81a4a56ff7eaf9cb9b",
+       "style": "IPY_MODEL_897551b76a84419cb667c6a967995bb9",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U3.fits: "
+      }
+     },
+     "7c6e7bac493b4066a6a006bd57d65063": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7c884268f4ba44c5aaa05d1bdd5367dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7c8f3b66aec34afb8bd3c8ce6b5c5ad7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7c93a1d42b984874906694a1bd8c437b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7ca5b4e86a234049ad594fd7ac8b183e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7ccbc64acb0e40ad80f5ca6913bee772": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7cce927de83046c5a3d72467aac0690c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7cf498b20ce849d39b411aa3380bf0da": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7cf6828e1cae4249931a95466aa013d8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_ada71180a463463fa06fe478ee7420ee",
+       "max": 50,
+       "style": "IPY_MODEL_85e9a2ecfd5d40bf9944eb1df59cff74",
+       "value": 50
+      }
+     },
+     "7d3a4339aa3f48968b91d878c4b84fa9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7d3b736814f942278265babaa5892554": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3ae358df4743445f88fd524013bac439",
+       "style": "IPY_MODEL_10e0e015267e4f609edfa6e63c6ace15",
+       "value": " 9.61M/? [00:20&lt;00:00, 6.22MB/s]"
+      }
+     },
+     "7d3c21301aa84887a24a729d1e658cc7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_7ad6fae7ac344fccb575322bd623c616",
+       "max": 1353600,
+       "style": "IPY_MODEL_10f506c03ad746be8e3f02afae13dcf5",
+       "value": 1353600
+      }
+     },
+     "7d5bbe66ca364133aba95dea065b5de9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7d5be8fa4af64c5b8c09c861948de930": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7d8213cf791f480fac70f36dfcd77932": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7d9120db7d084aa0b0cba939c0063913": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7dbf10ee24824e05a48042172c4dc2b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_984c3415b79a4f4fb07f7218b5e5c5c0",
+        "IPY_MODEL_9fe1155522b1440baf95845fb2de957b",
+        "IPY_MODEL_00bbb102498548b4bb54af989a33df9d"
+       ],
+       "layout": "IPY_MODEL_0f70e1f1a87d4925afcd739c329e6193"
+      }
+     },
+     "7dd733d85fcc4224a6df7ba996e6f971": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7dfb4828e605407a98fb34ccd32aa32f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7e1783a9372b4f7b95ea8973718185ef": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7e2e2853fdd242fca7e532891c80cc7e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7e40b4519de7457f93515090b54881a6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4c31cf317a7d4805b379aab5f8cac4c9",
+        "IPY_MODEL_cdbe7428e42e4fb78541fd27700b2698",
+        "IPY_MODEL_332a1b9182be4bfc986a12d288ae94a0"
+       ],
+       "layout": "IPY_MODEL_85779cc85c5b4513bfe64251b8f1c865"
+      }
+     },
+     "7e9068e1b86b4142b0b68ad1cf2aa98c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7ef578999e5341f080859f9cb4b84f57": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_baaa73d0e9dd40b4924ae2e3ef8fc1a7",
+       "style": "IPY_MODEL_642a32369e49423e9ee02772d9d510fa",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "7eff607d1b7c4531aa371073de87718a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_310f8979543c4776adec79c6e50b7e8c",
+       "style": "IPY_MODEL_52633550a961431e928d01bb39a9e823",
+       "value": " 48/48 [00:03&lt;00:00, 12.37file/s]"
+      }
+     },
+     "7f033808831746e0a16e07b577c19c24": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7f08ae04ac99423fa487be8964db9c2c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7f2bce35bfa645589408db1f7810da30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7f4ee2c158d24ee4ba44c2afed2c19d0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7f7879b64d674b12b9452a1c85c9cacb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_50481fb42cdc4a7d8c693a0945df1fea",
+       "max": 45014400,
+       "style": "IPY_MODEL_ad470d44d18b4fe2afa9fff5e83525a6",
+       "value": 45014400
+      }
+     },
+     "7f888f244b3047a3b169fa6873009d99": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_d353947c9c4643499d2554d7617b6dae",
+       "max": 8861760,
+       "style": "IPY_MODEL_a6dfbdfb8ad54dc2b95e8a1221970482",
+       "value": 8861760
+      }
+     },
+     "7fbf50ac3aa141dfbce5ce008b7efe1e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7fefb175e64b4d79b7986561c52cf804": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8007679255674ef2a3777f91daf5323d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "801fd46aba3142dfbadc74efab6bb189": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "803593ab397046d9a440666aa1631097": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "805dad429fea44929f69e1b2d73b9bb7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8071124769d64521a2a0ed9b841381c5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "807b053ef994481190bc2f9e7135842f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_704b139e08034185b4c43fb743566fed",
+       "max": 45014400,
+       "style": "IPY_MODEL_fc94dd9de7a245b3aa70ca90bc9e6296",
+       "value": 45014400
+      }
+     },
+     "808af21424eb45f4aa32f4a8b85f987b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_fbfe79f4218e47f8b154052781ee226a",
+       "max": 9331200,
+       "style": "IPY_MODEL_a18db8d2705b48e7b55c682bd5f743db",
+       "value": 9331200
+      }
+     },
+     "809feafb33bc4485a96795b3156a65a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_3b2895552aa34beca29cb8cd505b77b7",
+       "max": 9705600,
+       "style": "IPY_MODEL_41cb2fbd831c4c3d952617dc37ceeb06",
+       "value": 9705600
+      }
+     },
+     "80c4b7b3b18848408a27d793507cb4ac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "80cfa2db065a4dbe871629a9b6aa5178": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8142b2d1698441a5a8765b87bcf79d88": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "81af68b909f04e08aa9d7c7f9f4b1e30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "81ef3e4e98b24e098fb22226b56e3489": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "81f7d1e45b1b495ea37b8574c481df34": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "822422353e4647988bf28338571e82c9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8233ebe494444cfd9230191a13e426c9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_732caedc944842bd90aaef3c2eca44c3",
+       "max": 394560,
+       "style": "IPY_MODEL_687d69ea55f04cd0b81098568587f822",
+       "value": 394560
+      }
+     },
+     "8234120ba36744a99e1b9832c604fb86": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "824052b899d247baa6b25c6e0e6f4109": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_30d8ff5fa1c04282a5f0a05ab2823b23",
+       "style": "IPY_MODEL_4088e8893a074f33b771bb8a50d09b10",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "824f00d74ef7497399f37c5adfe044a2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "826039c2f9f7488ea597b3fa516b114b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8265216dd46749db9f04a27215f3925d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "82ba988aa92c4e3aac2dc4685e82dfd2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "82db625690d34eed9ed182614d3b2a16": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8300698336fa44fea20a43b36d8b5483": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8322be4fdc564b27b3afe23696051ac1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "83470dd5380e44a098e89704f244797c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9c90644689914effb9a6842ef4ea2501",
+       "style": "IPY_MODEL_f703c8ba10e74d91a744d2260b4d3a8d",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U3.fits: "
+      }
+     },
+     "8359284f5bf14720be3fd335a62426f4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "838d8bc4a6cb42abbcce46df59664110": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "83915447e6514ac1bc0a3277dd61cbf4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_35d3706daec44500832b40a61fbdb94b",
+       "style": "IPY_MODEL_22fe94a518764ad1b5cd671ae69d4efb",
+       "value": " 9.73M/? [00:15&lt;00:00, 5.71MB/s]"
+      }
+     },
+     "83b3295ffb824099a64a213fc0d09809": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "83e9cbb432d047fb8e4844ce2fb82609": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "84163155f14b4e8eb60d79d844d5daa0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4ad1012fb3b04fd3a868589e1347686f",
+       "style": "IPY_MODEL_4722c67ca57440ba937a4a4ef4b966ea",
+       "value": " 1.35M/? [00:20&lt;00:00, 1.88MB/s]"
+      }
+     },
+     "845f67c9b98e4d2c8afadf103524b9b9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "846841aff85c444e9e2ee0822d072f3a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8480f793680c4312b4c277a21ce133ff": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cf6d35214f064fef81436a08abaecb30",
+       "style": "IPY_MODEL_6ec1231c84dc45e5ba392a9910ed73e1",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q1.fits: "
+      }
+     },
+     "849fa4e3dbe64775a7924a1e390d550a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_1d7f7f3fd5774bbc8a3e84268b2bdc35",
+        "IPY_MODEL_c2bb44d18d194a1e9fb66763f63bce46",
+        "IPY_MODEL_e9c262d8cac1430ca8d1f32e4e9e761f"
+       ],
+       "layout": "IPY_MODEL_4ec9add2861b4dedabbe6ef46c4d5b6b"
+      }
+     },
+     "84cf45c227ae4fddaef0fa6fa7f0d09b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "84d9ee028a024181adf1be668e1571b3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_7dd733d85fcc4224a6df7ba996e6f971",
+       "max": 25,
+       "style": "IPY_MODEL_8e09d81487d347ba91cecc1bae7f7f18",
+       "value": 25
+      }
+     },
+     "851e114a42c146d48fc3bd00896619d9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8523c2848a22447381731d956dfbd0d9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "85779cc85c5b4513bfe64251b8f1c865": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "857b5474ebd945f59e9d697914386f9e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "85c21a598cd74fcfa207f4ba500084cc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_67148bf5df5c4d2a8d4267ffa090aa97",
+       "style": "IPY_MODEL_449de9ad6602447dab9a0614c2770249",
+       "value": " 9.20M/? [00:21&lt;00:00, 5.15MB/s]"
+      }
+     },
+     "85c820892b6a445ba1ede0274dd8b8c3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "85e9a2ecfd5d40bf9944eb1df59cff74": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "85f5f0f2727d4b3495cd6567b41e8a9b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8608987a16004f0c8fe86bd2c41b4eaa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8642bdf26b5f4fbfbe6ad55e3469218d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "864da73585f54b98aee9770bdee225a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_689373b9e9e24c3687a48d15c19aa4fe",
+       "style": "IPY_MODEL_eb7847a3e25d4245a848be9178198260",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.chisq.fits: "
+      }
+     },
+     "8657e2190e684209879ae0c05ada467e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "867786caad4441e59b029295c8dfde83": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5ba020f2b3ff45a39a0c858fc3509e3a",
+        "IPY_MODEL_f15f6559d4354736b4c0512fd4a18518",
+        "IPY_MODEL_c82cff25208d487baa84ad04bf30d3c5"
+       ],
+       "layout": "IPY_MODEL_9c43b31816f54052a8301ba6f4795108"
+      }
+     },
+     "86795b59c45d4bffb30cb3f73345c3b0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_10a7fb8a47844918b3dbacf2d4c6a6f8",
+        "IPY_MODEL_79734988edf6481ab4c9db56a3c2eb14",
+        "IPY_MODEL_a7af69067efb443c8d8dd68b2cc0b86c"
+       ],
+       "layout": "IPY_MODEL_7c8f3b66aec34afb8bd3c8ce6b5c5ad7"
+      }
+     },
+     "869b96db257144339d034fc7656ab784": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "86a003d0d5174a6ba99998add6aaf9de": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "86c5ce59f3454eeb95cc4a9324595780": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_24b3bfcd18a94550b93a476806a7c4e8",
+        "IPY_MODEL_aa627e137a4e4f4182260e7f360c14da",
+        "IPY_MODEL_b48d8529c2e742e1ab135a236175e1fa"
+       ],
+       "layout": "IPY_MODEL_82db625690d34eed9ed182614d3b2a16"
+      }
+     },
+     "86d4d866ccd14dfba37958dea12e22a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5d2d4be8b61843ffbf51e5a74f16bb94",
+       "style": "IPY_MODEL_6e8b2edc87a0488f976654f24367d09f",
+       "value": " 9.70M/? [00:16&lt;00:00, 6.15MB/s]"
+      }
+     },
+     "86e36f0694524f98a0e7d499a22c2cde": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "86f8aab4dafe4b85ab7f124af6759719": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "86fc91e619844a8f85cc24c8a9f6baeb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "86fe2ea3e0154a5796da376587cce562": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cfb4f4ed18d44bbcb871d7ac8392a0f3",
+       "style": "IPY_MODEL_719912dee930419ab266150e6db7130e",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.conv_flag.fits: "
+      }
+     },
+     "871179122e5e4daea1c2dfc19080d341": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "875ca204410441189b64082ce288d676": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_0706f1be0acc4e24a533970ea1294f65",
+        "IPY_MODEL_1cfc0ca8c3e9484c96e40106ce4702b5",
+        "IPY_MODEL_5eafe9863bea4bd198cb29c0c51366f3"
+       ],
+       "layout": "IPY_MODEL_0b0ef505e69c4da7847239cda158b436"
+      }
+     },
+     "87b482ce342b4a61a0f7b2a888b93b6b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "884463b2346d41a4a450a941742ec072": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "886b6de1f2e442f2bae536e3c94cba66": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "88ac13870ed34f0cbe71e0e4545a3597": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_f4e4207b13b949e9a93c073733798777",
+       "max": 15154560,
+       "style": "IPY_MODEL_fa8d7b3c26fa4bb1bdaeed3e0682f195",
+       "value": 15154560
+      }
+     },
+     "88bacd6af6dd47b595669ca82e43b18a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_341d6ef74bc24e27aa1879b6674d324d",
+       "style": "IPY_MODEL_a9b6dcc2bb0e40c8bff1ae2c5c9526c4",
+       "value": " 16.1M/? [00:19&lt;00:00, 5.87MB/s]"
+      }
+     },
+     "88c40ff77235462cafc35450b14be0f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "88e064602cc04495b619c298d347407a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_21cc435eafbe49cb8778d09bb571c2d5",
+       "style": "IPY_MODEL_c70b3692061d4bd694ab9c3c902872b4",
+       "value": " 285k/? [00:19&lt;00:00, 541kB/s]"
+      }
+     },
+     "88e377dfc31e494c8c4951b575f3e2cd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "88e7c11b73b54ccc9402f872848b05ae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8912279664e7403e9c3deb35492d9d7c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "892920d09d4c41f6abc9c2c90419614a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "896dd0d8b4b74720a1d6343c5da6b1c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "897551b76a84419cb667c6a967995bb9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "89759427bdf642b5809c5f4a9861ee40": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b48b597cd6834dd4ad9177c341c538d0",
+       "style": "IPY_MODEL_3845c0eede3f441a8169a36b3ff10c25",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V0.fits: "
+      }
+     },
+     "8978033e00c04322842dd7fe8e1c898d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "89a157eb73054259b9b17019ea686522": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_7b23425a269044caa623ff03027deecb",
+       "max": 20603520,
+       "style": "IPY_MODEL_3559c208a50d4bc2adfe74dd5080a936",
+       "value": 20603520
+      }
+     },
+     "89bbbfcb03e649d4befb1b375fc64e11": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d56cf033588f40e9b89128b19f848b14",
+       "style": "IPY_MODEL_e7d82ef7c4b34661a7b3976952a3e155",
+       "value": " 14.7M/? [00:15&lt;00:00, 7.99MB/s]"
+      }
+     },
+     "89ccfbaac0564539a35e71dfe302512f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "89e14dc99cd0404abb4c1d9e84099277": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_63b0b93773f24ccc92bf090cd443fc1d",
+        "IPY_MODEL_599cbc30dd524d488aabf73bcf5e0d92",
+        "IPY_MODEL_2d2fcccb93b9465d999c5641f44d7c7e"
+       ],
+       "layout": "IPY_MODEL_1240354c16f74fbda560cbb9049b248b"
+      }
+     },
+     "8a16809e0c184214b2dcbf5e7cacd45e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8a1c755c58344fe3918781521aaadae6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8a21c6d6586f4b1a9d5d831c068abf30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8a3005742f9744a79d800c7c8022a49a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bc10550c8441433faeff104eac72e99c",
+       "style": "IPY_MODEL_31385ac126ff42bea99a8400d7272693",
+       "value": " 25/25 [00:02&lt;00:00, 12.12file/s]"
+      }
+     },
+     "8a74b7788980491c83047e630a6b0ed1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_043eb95d6a1b440ca0ab5fb01ea5844d",
+        "IPY_MODEL_059a49ae9b25457db8a35a0245760a1b",
+        "IPY_MODEL_1b83da54b458432ea69c343995cbd814"
+       ],
+       "layout": "IPY_MODEL_686058f6288d429596802be2367f5225"
+      }
+     },
+     "8adce10e13704cc4a833b08bb9617cdb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8b10af0cc2164e9aa50c6a8900ea46bc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8b3bc79da85d4bae8bbdca1c6c77ecb6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8b7909dd5d854305b18d726b1407a326": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8bae7879077f44b38ad6bc60381edd9e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_40e7cbd7c44140c5b7005118d90c88f2",
+       "style": "IPY_MODEL_95738727e135413fb75f6a13baa0a8b9",
+       "value": " 21.7M/? [00:21&lt;00:00, 5.10MB/s]"
+      }
+     },
+     "8bdfd4f2d556485da0a0942b958a6f47": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_46f1c41ad7a44d49bdaaf2c590bfa279",
+       "style": "IPY_MODEL_9c2d048cd8b04af3bd1becd7c9b28d9f",
+       "value": " 395k/? [00:19&lt;00:00, 635kB/s]"
+      }
+     },
+     "8c0972ac7ba44dd2a05f2588f9a373af": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c0b402425124db2bb930420e52ca095": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c246ae312974b028dfb765bd9cca3eb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c26834f09824f35be89c0d5a2b44526": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c305f0a403c4c308f5ee226963882cb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8c542ccf656a48868a40ca33d275d8eb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c6801fb09bf4e7daa73e1c41c1ee303": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8cc7218380c642c9a6c77885741ddace": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8cd651cd755d49c5ac2a2b9a4a978f77": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8ce3ab8db15d4c3dbed695fd39468683": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3508b2ccfb574e67ae49189c0ad870f9",
+        "IPY_MODEL_0509964683814e0783684642660e8e5f",
+        "IPY_MODEL_4805fe6cedf0445eb10ee9ae8311cd61"
+       ],
+       "layout": "IPY_MODEL_86e36f0694524f98a0e7d499a22c2cde"
+      }
+     },
+     "8cfbadff3ab145099d383decd1e3453f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8d4824acd5c54456807182971e3dd741": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8d5e54aa03ef41e2952fc0d739a23601": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a7a980d114124bebbd25d2605724d4ef",
+       "style": "IPY_MODEL_f24aa50463f7400f855f24ebc48c0a1c",
+       "value": " 48/48 [00:03&lt;00:00, 12.32file/s]"
+      }
+     },
+     "8d7ddfe99a8b46f7a80475ed167d2f78": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_38e7a476989545259627bc6f9649432e",
+       "style": "IPY_MODEL_7e2e2853fdd242fca7e532891c80cc7e",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "8dcc0a14347a4cdaa4876bdc828f1fee": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_181009e56df64d35af8222d5e29091ae",
+       "max": 9599040,
+       "style": "IPY_MODEL_98309098b5bb4af4b8c4b1215a80cea7",
+       "value": 9599040
+      }
+     },
+     "8dd7d631000741d094b979cecc3154b7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4afcc28d287a465ca95bc3a2c908d86b",
+        "IPY_MODEL_d3cc6d7e102341528cf2021cc2d4a8d3",
+        "IPY_MODEL_f0c60be22c184d6d8efca303aba39067"
+       ],
+       "layout": "IPY_MODEL_49d2a267b1bf49e4a280de7b9648f7a0"
+      }
+     },
+     "8ddd17cd395141138dc0f370d28970c8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_566e0a0cb886460cb33831e8fc965a70",
+       "style": "IPY_MODEL_202ce5501d644127ab5cb9841d9b7f41",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.Q0.fits: "
+      }
+     },
+     "8df11c98f600454e9cb0420babdad8dc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8dfcd654095d49e7ac78ea0d4b936dd6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8e09d81487d347ba91cecc1bae7f7f18": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8e22eb3cec774bd99b50d500c2a58ae8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8e745841024d487baeafe5081988214c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_dc96cdc88ce041a08476a28052a103c7",
+        "IPY_MODEL_4da3879b55a84491a9ee491369a56271",
+        "IPY_MODEL_72aa1c083f054177b1548da0939a8138"
+       ],
+       "layout": "IPY_MODEL_1a6f841a849c42b09b61abf3a59f1df6"
+      }
+     },
+     "8ea98e5d13944bcfbba459be43e77c62": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8eb764b8f00e4b57b77df99e6bf338a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8ebb089f852e4895a9a4cb1055cf5875": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e934546a608941e1a9d389a0db792019",
+       "max": 21663360,
+       "style": "IPY_MODEL_01e39607191541dbb384da1082329d4a",
+       "value": 21663360
+      }
+     },
+     "8ebdaebf3a744ed5940af98e960476bc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8ef2acd02db244bcacdfcfd7ae7c1d4c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_00d0918a517d4b94b67faaf5aa1cd7b0",
+        "IPY_MODEL_47bdd1c6b782451985f46ca042895bb3",
+        "IPY_MODEL_263e3d2664b4454786de3fc69cd8d452"
+       ],
+       "layout": "IPY_MODEL_4147c93baca1436eb64e942e16bedda5"
+      }
+     },
+     "8f21f2f3b40d40828c3f32a77493949a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8f4f8dd77f3941b2b292e71e340ffd8c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8f7f1c4179824e8ca3f3d3d65200f703": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8fa521e7798f498686c55e841c049fc3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8fb61f080d644168a6096cba608ffe4d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8fd7ff5e7a634f7c8d96d0ab27608a6b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8fed72b027f94671a1c2cd0a1af80337": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8ff671458aae43a983cd5902ff7b5e67": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9050dbbee1b945858d16defeb166606a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_22a04fb6ffa74990b889870895a9df7b",
+       "style": "IPY_MODEL_3ec15ec5113649e5975d62ee8c660ed4",
+       "value": " 395k/? [00:15&lt;00:00, 858kB/s]"
+      }
+     },
+     "907bded6abea4fdd9d60f527005ebdc8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6db70168c4604ac2bc4026c91b564536",
+       "style": "IPY_MODEL_53a8c542279e42b4843ed20401ad9bcc",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field.fits: "
+      }
+     },
+     "90fab7e5523648fb86bcdf71148c71e6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "910b370069c5499a8a2513732de38274": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9126a205cbff45db9c1e819682f0e8c6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "912fc2053e8c4a0c9c273659332f3e24": {
+      "model_module": "jupyter-matplotlib",
+      "model_module_version": "^0.9.0",
+      "model_name": "ToolbarModel",
+      "state": {
+       "layout": "IPY_MODEL_4ddd2e526079473bbae908cf6c005abf",
+       "toolitems": [
+        [
+         "Home",
+         "Reset original view",
+         "home",
+         "home"
+        ],
+        [
+         "Back",
+         "Back to previous view",
+         "arrow-left",
+         "back"
+        ],
+        [
+         "Forward",
+         "Forward to next view",
+         "arrow-right",
+         "forward"
+        ],
+        [
+         "Pan",
+         "Left button pans, Right button zooms\nx/y fixes axis, CTRL fixes aspect",
+         "arrows",
+         "pan"
+        ],
+        [
+         "Zoom",
+         "Zoom to rectangle\nx/y fixes axis, CTRL fixes aspect",
+         "square-o",
+         "zoom"
+        ],
+        [
+         "Download",
+         "Download plot",
+         "floppy-o",
+         "save_figure"
+        ]
+       ]
+      }
+     },
+     "91555c24befe441985b595ff160545c8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7c2f3c6e0e454d63976f817541765e2f",
+        "IPY_MODEL_eb1df00d01c74662942e96f4fde68146",
+        "IPY_MODEL_7d3b736814f942278265babaa5892554"
+       ],
+       "layout": "IPY_MODEL_baceaf53d6ce49f794c0bc1eefa31f66"
+      }
+     },
+     "916ca57894f04ac489a8fc82bf1fec48": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "918068903cbe498dbeb610e96a5809fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d198ee8cd3b24b8fb1cc6b6e7ce4766d",
+       "style": "IPY_MODEL_c3df8e0bbc934abd98e8e47540f3209e",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.vlos_err.fits: "
+      }
+     },
+     "918f19f9b790464eae2faa75315583c9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "919ce1abb7424d36bebd7860d03ac1ac": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "91a1c575af1d464eb3e81bd2d1dd076c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ed17ab117b1041a68672e56493b0475d",
+       "max": 9570240,
+       "style": "IPY_MODEL_7c884268f4ba44c5aaa05d1bdd5367dd",
+       "value": 9570240
+      }
+     },
+     "91a287a940d84f6b9008f38936a241af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "921553bca1dd49f6a5a5dd82d3ce43b7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "921fb89aeb814f3e8c7514cb6d2f6c7b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9237e7efa8fb41b6b426527725b52d83": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9248ccc6277244ae83701c38c4c5e6d5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ffc31fe47ba04302b99569d0b2045e39",
+       "max": 9573120,
+       "style": "IPY_MODEL_81f7d1e45b1b495ea37b8574c481df34",
+       "value": 9573120
+      }
+     },
+     "9251bcadebcb4fc38c1a497298c1675d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "92810cfea42f4c3fbdf390a1e9b3f334": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "92a9c4567f3447698388c2b31b35ec4c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "92affbdc0a6746c7b3342854f8b91aa4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "92cc705a281d405aaf4e7a48270b814e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "92d0a6fb24994a7a8773b727b48084c2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fcb82cc8f87342869f81a30dfa834b88",
+       "style": "IPY_MODEL_3521b8b376e44494b94720ba433f60fa",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.I1.fits: "
+      }
+     },
+     "9300631a8750491b9a078ee6286e72e7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "930d7e55541d4642808ae762de3b6801": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f9243cb6e2794557904aadd8383d4f75",
+       "style": "IPY_MODEL_ac7fb5e86e524cfe9cf258e607f2a129",
+       "value": " 19.2M/? [00:17&lt;00:00, 6.43MB/s]"
+      }
+     },
+     "93150beaf16d4f2ca8435387df2cd857": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d10e5ccf45cb49ca8c57e5103a0f981a",
+       "style": "IPY_MODEL_7450e8093ba54a44a04ee2e5c095afca",
+       "value": " 15.3M/? [00:19&lt;00:00, 8.10MB/s]"
+      }
+     },
+     "931e55c01ebb4919b5aae2c4dd71d0a1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9348d1483f6e48b887ed5299c889ccbc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d56b485c544e45a185560528dd7a6d83",
+       "style": "IPY_MODEL_c2364ecb73494e078e174746408b769a",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.alpha_mag.fits: "
+      }
+     },
+     "9355e7f6e3d0434b87e318bbad733c13": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6b6597fe31db4b35a9c3d22112bf952f",
+        "IPY_MODEL_9a233e8b985b4378bf3aa44b627093a2",
+        "IPY_MODEL_7048be659d934bfcab2f0d0127da1c64"
+       ],
+       "layout": "IPY_MODEL_5e49534ce2bf48b0b4c561c7430ab05d"
+      }
+     },
+     "9364bc884c454bff8f68175f75c8975c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_23d37d49de824b4ab211eb287bebd5e2",
+        "IPY_MODEL_3a3a8fea322b470c8741198f0490c796",
+        "IPY_MODEL_9f5562df456346c6a3c137eac0385069"
+       ],
+       "layout": "IPY_MODEL_5ae270136c324102a04b3911a5f45251"
+      }
+     },
+     "9372696bd8e54942a4f1f0d21413f233": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9379565d0f3344719a0c7e9d21d097be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "938ea2cfb85f4debbeeddd1211bde67f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_d69d7fe8312a4438b819da76f426e78e",
+       "max": 20609280,
+       "style": "IPY_MODEL_c7d6351fca014bf09ea78782eedd1328",
+       "value": 20609280
+      }
+     },
+     "93b70515aebf4b6fbc2612e51645ec4c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_238b4d2b40334d20a7719c3004b7dc22",
+        "IPY_MODEL_395cd50b27924e07b4a8205001548d4c",
+        "IPY_MODEL_461ed12c491e4af6a23bcc240645a6f2"
+       ],
+       "layout": "IPY_MODEL_03692eb366c640c6962d74a163ff5d7b"
+      }
+     },
+     "93d65c50827a4310855c0a963a12bd3c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_fcbb51d7ca3242599596762152b6a5cf",
+       "max": 15278400,
+       "style": "IPY_MODEL_8cfbadff3ab145099d383decd1e3453f",
+       "value": 15278400
+      }
+     },
+     "940a892b40044269bb8daa5429eb8db8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4e05d3c355f341dda5281c0e4a94e389",
+       "style": "IPY_MODEL_6360ac67976547a7b99992c16a3b71a9",
+       "value": " 7.96M/? [00:19&lt;00:00, 5.54MB/s]"
+      }
+     },
+     "941ef5a1e71e4a5597b15821f7536151": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "94276fc69e21487c901eddb23a5a0da0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "949215e924124da49dc5574f761a77ba": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_53429f131c3c47bb8b5fecfeaafe4efc",
+       "style": "IPY_MODEL_c85fe0328c4341b890196e649c1e75f2",
+       "value": " 20.6M/? [00:14&lt;00:00, 7.40MB/s]"
+      }
+     },
+     "94c89c11f9dd47c69ab5e7d24454176d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "94f100d363a844928aa912ced7b66bd2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "94f631572bb64045948413a6d2b473a5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9521020276e94583ab7205d53be491f3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8a1c755c58344fe3918781521aaadae6",
+       "style": "IPY_MODEL_bc9245fbd05a4b37b95c56dcd1000145",
+       "value": " 45.0M/? [00:18&lt;00:00, 13.3MB/s]"
+      }
+     },
+     "955f485b58c14003ba237819ba8c3f6c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_ac2b2ecba9664fb5aca04cbc2a025548",
+        "IPY_MODEL_63d72e7c3c154e46b7a1bdda48122718",
+        "IPY_MODEL_3d386fc334a44e4ea35fc9b25f73686c"
+       ],
+       "layout": "IPY_MODEL_4ea10411e92d4ceb8427b5ff9cb92e4e"
+      }
+     },
+     "95738727e135413fb75f6a13baa0a8b9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "95bd6103acd34f72b2e8aa8c0bfd50a4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "960f36aeac704d25afa55174d0fd1b70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_271586b89d1f4fb2915ef39bbe8e2a4e",
+       "max": 9696960,
+       "style": "IPY_MODEL_c49d2c1fcdc44d18b4551ae68c4f4ad7",
+       "value": 9696960
+      }
+     },
+     "9621297df1d14742ad8b264668e8befd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "963d95194cf441529ad68d1f93ae3c65": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0aad326e75ff42bcb707d2f4743f89f5",
+       "style": "IPY_MODEL_eafaf8f930fa495f8d5e44a2e9009080",
+       "value": " 24/24 [00:02&lt;00:00, 12.16file/s]"
+      }
+     },
+     "96655b99879a462182910acf00948690": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_931e55c01ebb4919b5aae2c4dd71d0a1",
+       "style": "IPY_MODEL_8a16809e0c184214b2dcbf5e7cacd45e",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I1.fits: "
+      }
+     },
+     "96cc042c76414be3bd2afc9077b04857": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "96d1239d88634bd3aa75d3558acebd3a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "97145877d6cf4213ac1ef6f4d18f4d9f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "97355e9d737940cd902a8fe33783026c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "973dfc3a15f242c1b3ab5ddb03ab2131": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "975b03a7ac3b4a80ad5cd3a4665e0832": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "979e1558f1d246f28318bb2581ae3509": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_1574b981660948f7bfd8c13faa0b3ac4",
+       "max": 9702720,
+       "style": "IPY_MODEL_ff133777a9994f219c80af78feb8b72e",
+       "value": 9702720
+      }
+     },
+     "97c8f2fa0b0742ed99b404e5c4f95333": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "980e0f664f89444dba61bd698582279b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_49e0adc0c842490bae773a6e1bbf364e",
+       "max": 285120,
+       "style": "IPY_MODEL_b44e2ccfae794f6b91cebe99da016420",
+       "value": 285120
+      }
+     },
+     "98309098b5bb4af4b8c4b1215a80cea7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9836bd35b87c493daa2ff8b56d1a59ce": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_2569b61d6ae0450bbac22e009a4fd0f6",
+       "max": 50,
+       "style": "IPY_MODEL_3610e89a1dc1420fb8124d0032c8a0be",
+       "value": 50
+      }
+     },
+     "984c3415b79a4f4fb07f7218b5e5c5c0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_024d596a440d4083a85cd92e93f4dda8",
+       "style": "IPY_MODEL_a3afd5df4b9b426ea7ce9608749bca20",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.I0.fits: "
+      }
+     },
+     "986c3576494e474b9bbe806ec76fb8eb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "98a2f181242446bd9195a60d255ddbe9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "98d10a4c1d884f51ae594ff762b7569a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "98d9e3a64a3042408fd07408c6ae66fe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_69c385fd0c724585a5ddacff8218bfdc",
+       "max": 21663360,
+       "style": "IPY_MODEL_ac6cacaf3ea143fca857600dc8132488",
+       "value": 21663360
+      }
+     },
+     "98f6ec3882d34f168969cb06a4c81b6d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8f7f1c4179824e8ca3f3d3d65200f703",
+       "style": "IPY_MODEL_005f1830b8ef41e6bf03a7be86d395d2",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.V2.fits: "
+      }
+     },
+     "98f7ec3b32b64821878785af75bf5e37": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_4d320928138448f7aa24dd90b4e8397d",
+       "max": 9005760,
+       "style": "IPY_MODEL_c730cdbdfc894b63ad75eb8057f67177",
+       "value": 9005760
+      }
+     },
+     "991ef6f0faea4f2293550d042bf32457": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9b1ef675afad4fc0882326cb5952d82c",
+       "style": "IPY_MODEL_c8d4c52a8eca4f53be308cade01a85cb",
+       "value": " 15.6M/? [00:18&lt;00:00, 9.36MB/s]"
+      }
+     },
+     "99a110139eee462188958efc8a454c76": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "99a5820093894ee0b73ca3b554cbcfd1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "99c16436ad2142c2a40086ad23834baf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "99d07cd7a66f4937bb2eb76b33c6d3e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_8d7ddfe99a8b46f7a80475ed167d2f78",
+        "IPY_MODEL_fb8e58643df0473cb86239d308fdf645",
+        "IPY_MODEL_c85b24784bd5498eaba103eff6b2d4a9"
+       ],
+       "layout": "IPY_MODEL_0bb6814116944d0daf9b3cfdf9499a62"
+      }
+     },
+     "99d97b76a2cc4434833a239011b02b6c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9a233e8b985b4378bf3aa44b627093a2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_1fa74f72a6ee4723a323afc64a1e8c29",
+       "max": 394560,
+       "style": "IPY_MODEL_08fa9fe929e24474bf0d97ea9d3af20b",
+       "value": 394560
+      }
+     },
+     "9a24b72a6e86489791eda974fd423626": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7ef578999e5341f080859f9cb4b84f57",
+        "IPY_MODEL_6e0340a0e3b64a09866e61eb883e861e",
+        "IPY_MODEL_4232e52c2f834c259f1a31cea6bf3adc"
+       ],
+       "layout": "IPY_MODEL_6913fba89c8643ba9f0f8b1c56046dfd"
+      }
+     },
+     "9a2be989d354483fb549b01a49b7b279": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_c71b1c1f9d55454ea5bff6986d7f1767",
+       "max": 2900160,
+       "style": "IPY_MODEL_78b32e3b2c9b46adb98b3a5f7d18ba59",
+       "value": 2900160
+      }
+     },
+     "9a49b9a9c35e4368a02e2ec0c24e5f14": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9a730f9a7e954c568d8c56e4186cd442": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9a767db3711c455a8f6938ce8cc69b9a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_65a11191a9034622a52f327f6096ef51",
+       "style": "IPY_MODEL_9621297df1d14742ad8b264668e8befd",
+       "value": " 1.35M/? [00:15&lt;00:00, 1.56MB/s]"
+      }
+     },
+     "9a7c2230e6ba4695b6ad1bd9edeaf9fe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_7387bfcba7ad4525929c32d3fb4fbcf0",
+       "max": 14143680,
+       "style": "IPY_MODEL_293bc94b50794375951830b578e30423",
+       "value": 14143680
+      }
+     },
+     "9a841c0af1b54dec96af951a3131a4f3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_33aa6750877b4bb5baa720ba4ab7074a",
+       "style": "IPY_MODEL_501656aa60f54e13b179188b62dcfa46",
+       "value": " 9.57M/? [00:15&lt;00:00, 5.71MB/s]"
+      }
+     },
+     "9a91a470f0c245f3b5dcdf103db617cc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1561e43c32274a1e8ad53a8d4eeb127f",
+       "style": "IPY_MODEL_8dfcd654095d49e7ac78ea0d4b936dd6",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I3.fits: "
+      }
+     },
+     "9aec7dc68dc4415589368327a4aace8d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9b1ef675afad4fc0882326cb5952d82c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9b37358837db4e0fbfa5aa507d3ab262": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1d5e8819164e401e9c68fa5dbd7802e0",
+       "style": "IPY_MODEL_b67ddfcca28b441985a02ec115f1976c",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V4.fits: "
+      }
+     },
+     "9b607b0e21524c02a8937955881991b7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b2865fd22cde414ea945a84b1e4d3b17",
+       "style": "IPY_MODEL_ec42338510e24ad18db649cd98c40620",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.alpha_mag.fits: "
+      }
+     },
+     "9b6e897b3fca494180b9f653d9474e70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e6f09f0103da44829d11dc10c15c89cd",
+       "max": 14702400,
+       "style": "IPY_MODEL_97c8f2fa0b0742ed99b404e5c4f95333",
+       "value": 14702400
+      }
+     },
+     "9b937d9648ae40cc8627b5e0ac5b6909": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9bc4db1a868741ffb79e0e84f1cc975f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9bcbd93c978c45c0b90c2b525c8249e9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9bd37f34a3034fef8eb4459b7e694b54": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9becf18b9fc1499187796a604d0a2ed4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_20ba1c45a21f4c0c984d56da365730f2",
+       "max": 25,
+       "style": "IPY_MODEL_3e2995ca4c204192b30aba3770949458",
+       "value": 25
+      }
+     },
+     "9bfb88c014c744898efd83a2c4624bb9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9c2d048cd8b04af3bd1becd7c9b28d9f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9c43b31816f54052a8301ba6f4795108": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9c6db8fde3514c45bf520c7b185d17a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9c90644689914effb9a6842ef4ea2501": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9ccca25b76bf44fcb66055030e81656d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_f83ddc1dc4a1440686a3287ac000dbd0",
+       "max": 24,
+       "style": "IPY_MODEL_18a0b57b99a24d0897f778566b3aedf4",
+       "value": 24
+      }
+     },
+     "9d0ffcad67a244858feff9353b7a1223": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9d2385ef5069445bbea19f8c356ceffb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_1eabb108c76c433eae4b665af883bd88",
+        "IPY_MODEL_c535dd3f933c431abaae76d7bebce102",
+        "IPY_MODEL_4028a7cde64c48b9b9cce39e86d13eca"
+       ],
+       "layout": "IPY_MODEL_dc25820f723c4d98ae86ffc9a2185997"
+      }
+     },
+     "9d2c0eaf8769407786fad9c0177e266f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9d7a041c81f0487ba2bf0029ae2fe6af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_ff79837b066848eab884a78d92cf9620",
+        "IPY_MODEL_e1be240889f34a43a132d70475705a8f",
+        "IPY_MODEL_11b90cc60851429b8cab000cbe64f856"
+       ],
+       "layout": "IPY_MODEL_20a2c1d6da81454793c7ade2cb0f33ca"
+      }
+     },
+     "9d9106909b6246ecbe2089181c345f78": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_d3658a7f91bf48c28a630425eedad105",
+        "IPY_MODEL_604001a53c2b42b284666d3dc50023ea",
+        "IPY_MODEL_13b6f0e4556d4be2b23d6c82b81d3a83"
+       ],
+       "layout": "IPY_MODEL_c39434aa6b974292b6a96183a56ed2ee"
+      }
+     },
+     "9d9aef29aede4951892e24a7d6a88f2f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9d9d979ac33a4a16900a1959888cc3a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9e60600954344e27a72df2fc21bf7564": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9e6dc1b4238645448a472617ec5c2a83": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9ea32a82518e4abaaaa249e1165d2562": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9ead33c2c5144324ae85f314e4fc2631": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_11638f553bb04f0e82f9c4e49c67f0ef",
+        "IPY_MODEL_89a157eb73054259b9b17019ea686522",
+        "IPY_MODEL_949215e924124da49dc5574f761a77ba"
+       ],
+       "layout": "IPY_MODEL_21d3284cbcb148b5abe07903d2c20d05"
+      }
+     },
+     "9ebda3797d0e471ea8bada398f6ed570": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9ec4ff5b4c164afab9a68d35cf6e86c1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9edd891ea3d04469ae31d361f5c52a5c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9f5562df456346c6a3c137eac0385069": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_77ebe9a871de4b58aa6224bfd29c94c2",
+       "style": "IPY_MODEL_9d9aef29aede4951892e24a7d6a88f2f",
+       "value": " 8.66M/? [00:20&lt;00:00, 5.41MB/s]"
+      }
+     },
+     "9f62e6266d094293935b6dc6aa691162": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9f64e00bbf984f6694fccd837a4d7fde": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a72cfdaf5dce4cb6aa81cc812ab7bd20",
+       "style": "IPY_MODEL_10c5092ed67a41ff8064a1d0a55699c7",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.inclination_err.fits: "
+      }
+     },
+     "9f6a7b3069ee42e6a15c1cae38ea8575": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9fc3131e2333462db83c33f9ff0dce1a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9fcd7fd6a3cd45ea8c9953cd7323bcbd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_17d94e9e8f5547539dfba8edebe90120",
+        "IPY_MODEL_b0817e6680d94c598952127f269b3c32",
+        "IPY_MODEL_0f5e5d652d1a489b8c5d1f466e3c08fd"
+       ],
+       "layout": "IPY_MODEL_c638d10b9aae4b6998144c2e2a3343c1"
+      }
+     },
+     "9fe08c2b25984cadb5f8d93e98a41313": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9fe1155522b1440baf95845fb2de957b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_6414119f4aea4978a05026ad135a1229",
+       "max": 15292800,
+       "style": "IPY_MODEL_98a2f181242446bd9195a60d255ddbe9",
+       "value": 15292800
+      }
+     },
+     "9ff857a666d3480a90b015eb77d343fb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_14711b31264246b6ac419b17a674f675",
+       "style": "IPY_MODEL_7ac713c4f0424c628f7b05f043497753",
+       "value": " 21.5M/? [00:23&lt;00:00, 10.1MB/s]"
+      }
+     },
+     "a00ce9fb53fc4c5380e61e2351acaf41": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_ca0a73b63a984714b755504f09651023",
+        "IPY_MODEL_37d3ff51947a40e2bd0b45d43feafc68",
+        "IPY_MODEL_1100c0c83d034fb0a4f470663e110b4f"
+       ],
+       "layout": "IPY_MODEL_87b482ce342b4a61a0f7b2a888b93b6b"
+      }
+     },
+     "a019ad7e38244e31a667c1ed7710573b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8df11c98f600454e9cb0420babdad8dc",
+       "max": 1353600,
+       "style": "IPY_MODEL_cf0597694b41414c8ca9ceb8aa9d3e3a",
+       "value": 1353600
+      }
+     },
+     "a0359c725aa0495394921a50fae9f634": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a045f889d5c8434b865326ed48a9d92e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a04c3dbde59740099010207c1154d49d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1c1dd903bc0e4cf98cfb64e74dddee05",
+       "style": "IPY_MODEL_08b8f81d8b3346df981ec6ba9087e053",
+       "value": " 19.6M/? [00:21&lt;00:00, 7.49MB/s]"
+      }
+     },
+     "a0ee08d99716462d942823d16e571707": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a1376470833443ca85e15de457a26ec5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a13b074757cb4212b87323f49d64e578": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a1496dcbf1dc41aa8d70624df7c1eada": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a15d2dbf8cd441958f32f2cc92eeb491": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_9126a205cbff45db9c1e819682f0e8c6",
+       "max": 8746560,
+       "style": "IPY_MODEL_7c93a1d42b984874906694a1bd8c437b",
+       "value": 8746560
+      }
+     },
+     "a162d79c3b0e4d369ec3774fbd0a2b30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a16d4862df5f4b26a33975d386a71a4a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a172ec9861e14799b4b67127cc2004a2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a17ea92bab2c435bb5254777aeaf2a4d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a18300d43b064879bae1f30182441db5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a18cb9e0d8ee41dc94e8961801fae06e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a18db8d2705b48e7b55c682bd5f743db": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a1a7b8d967b14f30bb2f6745e4ed943f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a1df4e1317204b57a0778d4cc6c6c32b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_1ac5817999ab4d16bbddd392bcdb12f2",
+       "max": 9708480,
+       "style": "IPY_MODEL_ee93c7871253486ba44a98f4a97a0469",
+       "value": 9708480
+      }
+     },
+     "a1ea4a9001b74c5c9ba4307a89835958": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a1fb2009f9c14364803a5002584393f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a24a317d673a44368fae21f63f31f8d9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a2509d707dda421baef3ace2f0033f89": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a25abb79cbb74a27b18a46c11d6b05d6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_986c3576494e474b9bbe806ec76fb8eb",
+       "max": 24,
+       "style": "IPY_MODEL_0dda9dc241634835bb9fa9b8b1100e21",
+       "value": 24
+      }
+     },
+     "a27b2e7fa26240dbb0788a1a9cb8bda0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a2d431f97a344997ada0cf13cd9298f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a31e3892f4bc4fd08f79d4dccd86be88": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_d1f24d1251a648dfa3e52ff15b1beab9",
+       "max": 15278400,
+       "style": "IPY_MODEL_ab0b46c877224e028ce3bc65f4c1048e",
+       "value": 15278400
+      }
+     },
+     "a34da5ea69f04b47a50821490f7b5f60": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a3811e0f70bb497f9d6f4937f38214ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_45177c218ce1457c9a969c319f148a96",
+       "style": "IPY_MODEL_0bac7882736643dea22fddf4eb2caef2",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "a3afd5df4b9b426ea7ce9608749bca20": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a3c328754ab44efea564ec7dc7379f6a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_009bf82fcddb4c80b25ea987dc48a2f9",
+       "max": 21458880,
+       "style": "IPY_MODEL_fcdd77dbb8eb43e39f5d6d21318ef7df",
+       "value": 21458880
+      }
+     },
+     "a3d175ce4db54a6e9d8fede486e09de3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a3eadc4f25b343d9a485acc8992f695d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a3fbf889643a4697a7e41c94dc0e9712": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a402b3454b97450bb564fb8cbca5ae65": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_7dfb4828e605407a98fb34ccd32aa32f",
+       "max": 9696960,
+       "style": "IPY_MODEL_010b38ff757b4de392ad6b0515896568",
+       "value": 9696960
+      }
+     },
+     "a4429034e59e47999c177a82972cfd8b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_666dc583f77749a99c345111a3e821b0",
+       "style": "IPY_MODEL_69ff1941cf7b4a6f9daaa583ce9b7335",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V5.fits: "
+      }
+     },
+     "a453f2b314c8457c9382f4945a8c949b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_44327452ffcb4b70b489a8163e71492b",
+       "style": "IPY_MODEL_fa6d95dfd7fc451c88ca7df9df62df54",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "a45f9f6c7dd047eaa660aeefe2ccf7ae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a4608fb1f1a8460d99b98c39396ac7fb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_e1d58d007b0242e498ee64709c6e5595",
+        "IPY_MODEL_ca48dce856174b9ab66cb68ca8980980",
+        "IPY_MODEL_462b0d7d6bb545edb12b22e0fa8b1381"
+       ],
+       "layout": "IPY_MODEL_4a178e64002a45c4a0b63aec687dc7c2"
+      }
+     },
+     "a47729ff93af47879d78e4a4be0ccfcc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e3b871fc2bee4c86a476bfc8c0d999fb",
+       "style": "IPY_MODEL_4604ef3b2f6d4add8549baeaf60ecc99",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U4.fits: "
+      }
+     },
+     "a47ba27da6804ca0af02151a2467d330": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a4818710c435402c8c921a439f7f42ad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5083041d6de54c3795c185f352f7767d",
+       "style": "IPY_MODEL_a24a317d673a44368fae21f63f31f8d9",
+       "value": " 8.68M/? [00:15&lt;00:00, 5.02MB/s]"
+      }
+     },
+     "a482a317f9894c7db5d48c8136f5bd1f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6da1a356c8aa486fbde7973a823e20d5",
+       "style": "IPY_MODEL_3119ac1ea9da494e9006491dda45b74c",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.Q5.fits: "
+      }
+     },
+     "a48f799f7ed445b7aea7ff6502098f9c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fb0b0a62974e4d7889067ac69e20774d",
+       "style": "IPY_MODEL_7b619b9c29224736a52ac05645f4bbfe",
+       "value": " 20.6M/? [00:19&lt;00:00, 4.44MB/s]"
+      }
+     },
+     "a4ba7d5ff4f5480385c8b347dfcb762b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a4ee1ba568114f30a1bc230fbc868cf3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a58cf63c6b0b470589250d75b7498869": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a58e0507469140afa705c8fc5003601d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a600d833951a457590dc6bb8742c3876": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a60fed1f50924f5ca9b712a8e48aea6d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_470a3f84eb2a4a77a4e4a12f29386972",
+       "style": "IPY_MODEL_636d19802c0c4224a454358325e3eca8",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U4.fits: "
+      }
+     },
+     "a616d166fb2e4d3c8de8bc2cf30b85cb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_584c83af5b6c467e9ce8c46c2365cd81",
+        "IPY_MODEL_808af21424eb45f4aa32f4a8b85f987b",
+        "IPY_MODEL_d792f653a8e74d8b945b67f24539082b"
+       ],
+       "layout": "IPY_MODEL_4c65e3248c2c4ac38708f0897f8de8f5"
+      }
+     },
+     "a62b46f2e5414ba889098dfc01910db7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a62e3d6bdb7b42589e758a6526892305": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a64cb8a3267b4845b968b0ebca518272": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a6570fcb2588438ca77a620411e34254": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a6a4a7f78cf9410ca9b924e0e44eb28e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a6ab216562984612aaed99d04b18845b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6d2883f17a2e4ba4a4867066aa5d680a",
+       "style": "IPY_MODEL_370eaf3f85f84b09a64601d86d9cfaa2",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.I5.fits: "
+      }
+     },
+     "a6cb0276deaf43a5b29ebe091465b708": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a6cd23a77851487fb03b3351620e0d95": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a6dfbdfb8ad54dc2b95e8a1221970482": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a71ef0e47bb741b9b926cdf66e9377c9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a72cfdaf5dce4cb6aa81cc812ab7bd20": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a77047921faa4a1a9bb3029c886ed527": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_be51cd57adea4f67a4b9d855ac588a10",
+       "style": "IPY_MODEL_3e00bd7c39fc41f29805797304c6a687",
+       "value": " 16.1M/? [00:21&lt;00:00, 5.23MB/s]"
+      }
+     },
+     "a7a980d114124bebbd25d2605724d4ef": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a7af69067efb443c8d8dd68b2cc0b86c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_59d4d3acf39a43959b5ff6f0107a5d12",
+       "style": "IPY_MODEL_5796bc0a403445e09bf6df5b20fc54fc",
+       "value": " 10.4M/? [00:18&lt;00:00, 5.26MB/s]"
+      }
+     },
+     "a7d09d8f7a884441b16f9aa6812035eb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e9465a3b3dc24c47902606e061555881",
+       "style": "IPY_MODEL_db68b533dfa544c287e417a8e80d259a",
+       "value": " 50/50 [00:04&lt;00:00, 12.37file/s]"
+      }
+     },
+     "a80d778feea24b089f926546ba94532e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_61b45e83622645e8b15ed662076748f0",
+        "IPY_MODEL_d85c090b222744bd9e958149b86cc8cb",
+        "IPY_MODEL_dbf18627af3f445cbfbb964e1eaac9b7"
+       ],
+       "layout": "IPY_MODEL_764c91d2eb84479aa15a089f43cc9895"
+      }
+     },
+     "a80d8796d3d14639a36780916db9718b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a813c097b4e749aa89afb6aa0912ef0c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a817d675746245e18efb2e6850ea38ec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_363a8128517141dc85d9880a8da8ba17",
+       "style": "IPY_MODEL_0da833ab931f42349a05e0ae6b7c0abc",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "a819fe1a866841ac9c933b262b96b1db": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a822bb2f88fe4f7286d54e460e348643": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a82ae1126e084f3c846ee0f06faba2b0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a87203de602c437aa0a93734c2c9476d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a875112e08a44eb2876e698265bde734": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ea5064c7178846b8b4dfb6f6fe6ffdff",
+       "style": "IPY_MODEL_83b3295ffb824099a64a213fc0d09809",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.U3.fits: "
+      }
+     },
+     "a888fbeb87414258b464a5afe43a713e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a9179dd1eac74b6ebac3b43c0ca04df6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a93f239cb99e4fd7b5e33e7f98fc5140": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a9467ceaf1b542718df9c77111748a7f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a9494e29b8884e0493f22ddcb951ee3a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a959cae44be0495bbf034aac1e3c7571": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a974e4ca8df74ef08e745345447c4ed6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a9b582e46fec4e11be25afa4e9facc3f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_f25c126f85fc4c93b7c6152b51aba3f2",
+       "max": 1353600,
+       "style": "IPY_MODEL_e8bd70fedcb04217990b601548fccb5f",
+       "value": 1353600
+      }
+     },
+     "a9b6dcc2bb0e40c8bff1ae2c5c9526c4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a9f37d8daf0f473ea4c6fe41f81aec37": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_183c7fb9a11d43f29a658c51755a826f",
+        "IPY_MODEL_f71fb66a9c164e98aeb3a2c832711be9",
+        "IPY_MODEL_35747eb4983248359adf8ba9d45d8b07"
+       ],
+       "layout": "IPY_MODEL_a6cd23a77851487fb03b3351620e0d95"
+      }
+     },
+     "aa0ccb24db7a42168e3587f7f9575feb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "aa1662ec67864851b9bcfa389d4872e3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_40c9fc5e76334aeebf97ed1ac4cc2fd6",
+        "IPY_MODEL_98d9e3a64a3042408fd07408c6ae66fe",
+        "IPY_MODEL_8bae7879077f44b38ad6bc60381edd9e"
+       ],
+       "layout": "IPY_MODEL_cd99e901a3c946709e62f79f23fc850e"
+      }
+     },
+     "aa1b03a571fa42f88e4e132fe0d62cd6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "aa432630e8da4f0ca166463c68696591": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "aa627e137a4e4f4182260e7f360c14da": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_7cf498b20ce849d39b411aa3380bf0da",
+       "max": 24,
+       "style": "IPY_MODEL_a18300d43b064879bae1f30182441db5",
+       "value": 24
+      }
+     },
+     "aa8aa7b7190b4e2cba6674624ce7f992": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "aa9690a664704411bf147efcd32d3bc9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "aabb34e7599a45e69c5339c620ef5464": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_60d9e17c92f247aeacefaf8249b2e32f",
+       "style": "IPY_MODEL_daf9102dc4414aeba00bb4412b8662af",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.confid_map.fits: "
+      }
+     },
+     "aac7683f9046428287280c9e081da758": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "aad2eb230c9f48878f70b91b0101e5a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ab0b46c877224e028ce3bc65f4c1048e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ab4085600e964bbebd436e6985c35dcd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_47618c2b4008462688e2618ca50375df",
+       "max": 7960320,
+       "style": "IPY_MODEL_150888badc744bdda52291237f1750c0",
+       "value": 7960320
+      }
+     },
+     "ab47429010a741629a43b6e990827df8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ab7e8d6ef48a4f838ea069896bbfea5f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ef0be8f05ec14209801987d2c7865751",
+       "max": 9725760,
+       "style": "IPY_MODEL_9bd37f34a3034fef8eb4459b7e694b54",
+       "value": 9725760
+      }
+     },
+     "ac1c64e4c5444192b7a3d312b948e39f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ac2b2ecba9664fb5aca04cbc2a025548": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_68139d2f9ab14ce8842c5b715c7fbdad",
+       "style": "IPY_MODEL_1a84f98765564bd8aa9c3ca6430838be",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.inclination_err.fits: "
+      }
+     },
+     "ac4f6fa3320d4d50ab86f88d921798c3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ac6cacaf3ea143fca857600dc8132488": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ac7fb5e86e524cfe9cf258e607f2a129": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ac928b8db250402ab95a155c621fd244": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b2b47727b8e54351802aa9bdac8cc2b7",
+       "style": "IPY_MODEL_f328c6b769d042a9b79cea0ad32dcc10",
+       "value": " 25/25 [00:02&lt;00:00,  8.66file/s]"
+      }
+     },
+     "acac3ffb909b499a8db776028a0fa9e4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e58df4a0f21642fb9327de2ab84de9aa",
+       "max": 9204480,
+       "style": "IPY_MODEL_2d08072242d247718ac1ff546b03a3e0",
+       "value": 9204480
+      }
+     },
+     "ad0924953f444082b4598ecf5b6e061f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ad0b5dab15bb4d5d87bb41c967c946c6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_0aba60ccacbc4b9aa2fdcab9310b93ca",
+       "max": 8997120,
+       "style": "IPY_MODEL_27751caec3fc4e70a0a5b3493f90c578",
+       "value": 8997120
+      }
+     },
+     "ad143c5690cb476ab79da0ead6285558": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ad359fe9fa31469c865c15951ce76f1c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ad470d44d18b4fe2afa9fff5e83525a6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ad956c2384624c36b4eba5028b116863": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ad98dcb00d80427eb63b8107a6ea0f4c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_14f5f56915a346ad89ac03d0aaf90f39",
+        "IPY_MODEL_5ab65adefcb4413a97b0694b46cf3996",
+        "IPY_MODEL_1e2d01fedae7489183be2f48132841aa"
+       ],
+       "layout": "IPY_MODEL_df772f7545654cb980b9894101f93a1a"
+      }
+     },
+     "ada71180a463463fa06fe478ee7420ee": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "adafe6bceb8141f6b037d2380a07dde4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "adbf2dfcec4a4659994db46326d9ed98": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e6fcae3e5ab244139d717ed3a57a5b53",
+       "style": "IPY_MODEL_3d4e32535a0f4121815947c212378917",
+       "value": " 20.5M/? [00:15&lt;00:00, 5.72MB/s]"
+      }
+     },
+     "add5810c677847bc98a9e2b126f2d536": {
       "model_module": "jupyter-matplotlib",
       "model_module_version": "^0.9.0",
       "model_name": "MPLCanvasModel",
@@ -657,16 +12014,5109 @@
        "_figure_label": "Figure 1",
        "_height": 480,
        "_width": 640,
-       "layout": "IPY_MODEL_31d4694f7fb24631a56b992acf349b5f",
-       "toolbar": "IPY_MODEL_5cd3d9e4fcbe4c809740f6e68c088891",
+       "layout": "IPY_MODEL_079820ca51aa4287bd8f6a9807aade30",
+       "toolbar": "IPY_MODEL_6bce8e13c0494a0e8b39d758b59327b9",
        "toolbar_position": "left"
       }
      },
-     "a99f1ed5dd9d49c18cae00cc9cd49bab": {
+     "ae3b1810b8c34b009bcf2a51817f3bb2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "aea3e091813d4b0aad2f1ed163515dbd": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
+     },
+     "aee584462e4342c48a1e95f11834c835": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "af9905050a134fc7a36373586c244e72": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "afd342b118a642fca04958e8b0a768d9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cf05e948590543a19631ffbf62591997",
+       "style": "IPY_MODEL_a3eadc4f25b343d9a485acc8992f695d",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.field_az_err.fits: "
+      }
+     },
+     "afd62351847349eb9bffe283e91d9a1d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_5bdd009fbffa4686831d2d02716b6d73",
+       "max": 9731520,
+       "style": "IPY_MODEL_0d48590e47e04fe38ea4f98e92ca5c94",
+       "value": 9731520
+      }
+     },
+     "afdad62398a14d0db0a08fb915bf6f94": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3bfcdcee28b34dd295476f09e97a04ba",
+        "IPY_MODEL_ba7743ad31054820b67ce60464b314dc",
+        "IPY_MODEL_7356fe16f718447485b055f4d3890048"
+       ],
+       "layout": "IPY_MODEL_d4235c0cab3649b3ae010b4b6859f498"
+      }
+     },
+     "afde8f3c91384c9fa077a550d12f14d5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a453f2b314c8457c9382f4945a8c949b",
+        "IPY_MODEL_0d55e2d8ec4d4c88b4f5407592b4a315",
+        "IPY_MODEL_a7d09d8f7a884441b16f9aa6812035eb"
+       ],
+       "layout": "IPY_MODEL_eca18d19b34a4bbea8aa2c4bd8249a5a"
+      }
+     },
+     "aff835e0ed254c47896bf34db1d32652": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b013e5cb48bc4f4e87d962c0ce6e19f4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b02251a0a4ca404c9ee411d35c822d2e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b0663dedee4e427bafbee9c4a2eba136": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b0817e6680d94c598952127f269b3c32": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ff3e2dd8a46f4031a44f5d5ffc531003",
+       "max": 19215360,
+       "style": "IPY_MODEL_45ae75bd034340e8a978297089526676",
+       "value": 19215360
+      }
+     },
+     "b08fa4053c88481cbd74a069780e53fc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b0a23d2f849d409aa8cd566c93e1e7f1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b0a360376f124b03a2bb39b0d38756bf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_2678c7d0a31749b8b90ac5b21003e507",
+        "IPY_MODEL_8ebb089f852e4895a9a4cb1055cf5875",
+        "IPY_MODEL_09f79a734fa74c45985c003030deae25"
+       ],
+       "layout": "IPY_MODEL_8523c2848a22447381731d956dfbd0d9"
+      }
+     },
+     "b0eece8e1ae74efc9e06d33a8ecc6b37": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b0f59c3336474c4b93d0702082efd9a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_23f3d7a27ba249f1bfba0a5115777d52",
+       "style": "IPY_MODEL_d04d5de9f75e4aed9d111765dc3163ad",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.damping.fits: "
+      }
+     },
+     "b12a346beb014586bf604f9ec674803f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b1998b669cf34c138f37dc258e9f1173": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b1fede81727e42ffaf20f874de0a8cc3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b211e01fad9f44fd8feabe1a1eb9bc20": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_06ecfadf2ca94043ab603eed7fd16529",
+        "IPY_MODEL_d0ff9af534b84bcaae26988a7c5c3c73",
+        "IPY_MODEL_ef57b01acec64e5384a122c62c99b136"
+       ],
+       "layout": "IPY_MODEL_0b6aa4323a9a4fe494bdcc24bddc597c"
+      }
+     },
+     "b222f8c90dce41a79710f2c6abd924b7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_04bc20f0356e4923a006b5fe7389eacb",
+        "IPY_MODEL_6138d801259b440b9e32e9f1c6d3651d",
+        "IPY_MODEL_bbf51c2637d64ac7a71b0b2dfc45fadb"
+       ],
+       "layout": "IPY_MODEL_6eb28e66fe854964bab2a22bfefcfe4a"
+      }
+     },
+     "b240288545124299bfa2d3b18e7e7c78": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e2a1490c4e9c4c97812658c3ef6c62a5",
+       "style": "IPY_MODEL_8ebdaebf3a744ed5940af98e960476bc",
+       "value": " 1.35M/? [00:20&lt;00:00, 1.93MB/s]"
+      }
+     },
+     "b2865fd22cde414ea945a84b1e4d3b17": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b289fc8ae25d4d3cb16e50d9ba53a62f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c1f0a0303a0f41be82fcd002b5cc201f",
+        "IPY_MODEL_6977da333aa64b6a86b4dfec53d4db77",
+        "IPY_MODEL_e54a826f38e94c51b9b0236f6d643862"
+       ],
+       "layout": "IPY_MODEL_d88e79d9b8cf4f76bd59ba3d7ec9115c"
+      }
+     },
+     "b2b47727b8e54351802aa9bdac8cc2b7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b2d03115cb7642619284cdcd0207bf9c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_b737b2f003c14192af8e7be7fe904617",
+       "max": 14702400,
+       "style": "IPY_MODEL_bc7c2d6ff26147feb9e1e27448cae4a2",
+       "value": 14702400
+      }
+     },
+     "b327b900b7fb4889b4138beec7dee95e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b350e7ab57c34048a7c9eaa8d20b5899": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b36c62195ccd49a7a1ca66bd721be41e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_7a1e025d792d46e18681673d7e2258a3",
+       "max": 394560,
+       "style": "IPY_MODEL_cd0e5f878fbe444da98cd1e27b5990ea",
+       "value": 394560
+      }
+     },
+     "b391dcd0786b45a69da040cd3c1fece2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_46deabc5f4144408985ec3f300301073",
+       "style": "IPY_MODEL_a0359c725aa0495394921a50fae9f634",
+       "value": " 9.60M/? [00:16&lt;00:00, 5.11MB/s]"
+      }
+     },
+     "b3b98b339595496f86768069bf21ea68": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b3bb10cd9ceb4c4290f7b8b107f86ebe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_80cfa2db065a4dbe871629a9b6aa5178",
+       "max": 285120,
+       "style": "IPY_MODEL_fe7cc6d8c88e47ec8da51c47eeeca873",
+       "value": 285120
+      }
+     },
+     "b3e8269d75804127bf2c25d26afa0343": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b409b5ffb9e44a769b69b151f699c064": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b42ea14fc95b46fda310f79db7e41b86": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b431dc53f0754c55af4da803cc42bfb9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_92cc705a281d405aaf4e7a48270b814e",
+       "max": 16067520,
+       "style": "IPY_MODEL_6b22d4db3349479fa891021ba3d94066",
+       "value": 16067520
+      }
+     },
+     "b44e2ccfae794f6b91cebe99da016420": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b48b597cd6834dd4ad9177c341c538d0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b48d8529c2e742e1ab135a236175e1fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2944b38c6cbd4a35bf011c258dafff7f",
+       "style": "IPY_MODEL_ea352ab683694321bd5baafd279a3ecc",
+       "value": " 24/24 [00:01&lt;00:00, 12.27file/s]"
+      }
+     },
+     "b4be6bcfaf1040f4a2cfe607e0824433": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7ca5b4e86a234049ad594fd7ac8b183e",
+       "style": "IPY_MODEL_aee584462e4342c48a1e95f11834c835",
+       "value": " 19.6M/? [00:19&lt;00:00, 5.54MB/s]"
+      }
+     },
+     "b518db24c9ce449bb84b73ac83dc8276": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b547b70f18504660ac826a22528a7337": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b5cea73c61e34054998f38de02d06da2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b615bb83990c4e13856631f93f25479d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c61b0a97dc2c4dd2958165cacf180d02",
+        "IPY_MODEL_0b6f2de314c34ee5866679608ae76d98",
+        "IPY_MODEL_fa01512694f64369b5614757cad43f25"
+       ],
+       "layout": "IPY_MODEL_c261cc16a8b14661a341e99c5747385f"
+      }
+     },
+     "b6409921693d4861824fa6aeb4937700": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fa3cec6f1a08455e8137c480bd3d67f2",
+       "style": "IPY_MODEL_90fab7e5523648fb86bcdf71148c71e6",
+       "value": " 14.9M/? [00:16&lt;00:00, 6.74MB/s]"
+      }
+     },
+     "b65fcff52bdc433a8175fdf4fd582f95": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_4aec1b914cd64e81854fb6fdc19ce47f",
+       "max": 22766400,
+       "style": "IPY_MODEL_4258225aa33a4f2bbd0535444ced5cdf",
+       "value": 22766400
+      }
+     },
+     "b67d2adacec748baa8db0514ab0d64b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_bbad6c0954004dc4932ddc05f43433b5",
+        "IPY_MODEL_096ad4532a944c73986a4bfe5124becf",
+        "IPY_MODEL_5b5fc158585e4d63baddbba1e0e84f28"
+       ],
+       "layout": "IPY_MODEL_a13b074757cb4212b87323f49d64e578"
+      }
+     },
+     "b67ddfcca28b441985a02ec115f1976c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b69da738dee441f9a207b1ff81892940": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b6b8049a90864dc0828feed58bd39ba9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b7266ae7775c46879ab35453fc52423e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b726ddecb6434987bf227778d565b2f3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b72c267132904193b0c41fb39804ecd8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b734cf02c9144cfea8d2f2f1d5fba488": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_cc756d24c7574d6786d207ba7ef502c7",
+        "IPY_MODEL_3be771a783a24c9187fc4269b6e70b3d",
+        "IPY_MODEL_1d38bd6d1962405d9be5c0bf52547977"
+       ],
+       "layout": "IPY_MODEL_c5188477bf29481c92c77f73cd4cda4d"
+      }
+     },
+     "b737b2f003c14192af8e7be7fe904617": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b738f1fb847647e2b8fa2c3439933ee4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5f076dafd14d452b856412b7b419267c",
+       "style": "IPY_MODEL_382b7991b7b1452d9a8ad3b0d9dd59e3",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.qual_map.fits: "
+      }
+     },
+     "b743dcae1f1c4df6b29e2aef3546878c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b74a5935dfab49c2a102ec00fb7f3334": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8142b2d1698441a5a8765b87bcf79d88",
+       "max": 21657600,
+       "style": "IPY_MODEL_fcfb98f2cc9848ad9a6bdba7168568cb",
+       "value": 21657600
+      }
+     },
+     "b74f1cb525a64f77a504533158d043a4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b75838ff5dbf4f0baf6cbee721b1977c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b79023ae8263443482cbf0b47f098f2b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b7ba8721b8984766bc4fb2ee2dc81fcd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b7bf027eed94407a86aae51518377d0f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8f21f2f3b40d40828c3f32a77493949a",
+       "style": "IPY_MODEL_8265216dd46749db9f04a27215f3925d",
+       "value": " 9.55M/? [00:17&lt;00:00, 7.07MB/s]"
+      }
+     },
+     "b7dda19a1a974829abd461b96613b1f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b804d8f2577747778f680cc4e2fcfbb0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b85b8d21b702496aa761e08ffae2eff4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b885041d10734f138aaa4ea89bc183e8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_eb6c9815d42a4ef2b7d4bd89e898a89a",
+        "IPY_MODEL_e224d122f6904711a66e61106c74e145",
+        "IPY_MODEL_feb216d9b5ad4aa291e4068cef8e84d3"
+       ],
+       "layout": "IPY_MODEL_6edfb814ddbd41fa805e7b18803b00aa"
+      }
+     },
+     "b8914b0aeb8049f2821e5db34063c3eb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b8a1170351314ad9900eae6e43696ac4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6286c62d97a047cfb30ddd6494c9bfe5",
+       "style": "IPY_MODEL_dd16336c165c41b794933d2b3cd51531",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "b8c364178f704f9d9250f5ea81231344": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b93c82e4550c4b66adb14cbc5b8ed731": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b974c1b0d4f6467bab43e2f787c94977": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b97f582da759462badf0c47c964353f8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b98268f8aaa94faca5f851a2b6b9fe1d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8fd7ff5e7a634f7c8d96d0ab27608a6b",
+       "style": "IPY_MODEL_3b4d4e63b3e84674925a7d80b837fe95",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U1.fits: "
+      }
+     },
+     "b9ebd2ebde22491c904c8f1d1ba9c703": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_fb886e22433f4c64bf565198d346ccf5",
+        "IPY_MODEL_5bc672aa0b53488a8294cfe043715bdb",
+        "IPY_MODEL_533e42b4d3db42a4b0137181008e4906"
+       ],
+       "layout": "IPY_MODEL_0d528bcc9652403a947debd2591d767d"
+      }
+     },
+     "ba12c33d628a4733a0311bc4b645f109": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7f2bce35bfa645589408db1f7810da30",
+       "style": "IPY_MODEL_0cd797abbee140988d56989919c562d8",
+       "value": " 14.7M/? [00:28&lt;00:00, 1.13MB/s]"
+      }
+     },
+     "ba540adcce964ab4ac71b7550339cc3d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ba7743ad31054820b67ce60464b314dc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_6304e7b058684cd8a946af2a037d51ca",
+       "max": 45014400,
+       "style": "IPY_MODEL_a18cb9e0d8ee41dc94e8961801fae06e",
+       "value": 45014400
+      }
+     },
+     "ba78679151b240d2aa69bb28c55891be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ba92215a3ff64fcf836f1f8c8349d614": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_33807325b70a43199f36caa14f7ac1a8",
+        "IPY_MODEL_1af824c3bbb24732af881ed5a2198448",
+        "IPY_MODEL_9a767db3711c455a8f6938ce8cc69b9a"
+       ],
+       "layout": "IPY_MODEL_19dc0b63fbb74bb0ba0e86c0fb4fd301"
+      }
+     },
+     "baaa73d0e9dd40b4924ae2e3ef8fc1a7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "baceaf53d6ce49f794c0bc1eefa31f66": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bada7034346744419b36a0bf662fde84": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6a84bcf3c84743b6b771a83e3ff0d2b6",
+       "style": "IPY_MODEL_f58186a66e194648865940adf54f3e73",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "bafc22e734ef44e48614d538399b4346": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bb0c4a91aeb94cac9136042cf167f59a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5c3a69b51c44478ba9b2e5451e8c3e6a",
+       "style": "IPY_MODEL_8007679255674ef2a3777f91daf5323d",
+       "value": " 15.3M/? [00:22&lt;00:00, 9.69MB/s]"
+      }
+     },
+     "bb2a5f71a7fe42aea549fbdd7c4b2b93": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bb3b1712c1f843da951be484328baaa3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3acd01fb884d45d98e7a822ee41f31a7",
+        "IPY_MODEL_5d07b7d0bf444d64aa3c0a292a8a7b28",
+        "IPY_MODEL_a04c3dbde59740099010207c1154d49d"
+       ],
+       "layout": "IPY_MODEL_d6c9a08e03654e89a68593b53393d177"
+      }
+     },
+     "bb8a3dd241244e7689a0e8d09807bb9e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_63809399673842b3beaefa4a05f1a0b1",
+        "IPY_MODEL_5574a730745d46eea5325fedede34b91",
+        "IPY_MODEL_3a13233cba6a48b9bc6d4fd02548a38e"
+       ],
+       "layout": "IPY_MODEL_5076ed9f7a5940008536dc666c373593"
+      }
+     },
+     "bbad6c0954004dc4932ddc05f43433b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ed343eee5030454f9416fb699cfc34bc",
+       "style": "IPY_MODEL_99d97b76a2cc4434833a239011b02b6c",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "bbbdce95e9254130a72d45f52677d4b6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bbd7f92098124c5eb94706cf8ddbbb55": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bbf0de444f194aca89df3a0dd124738a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bbf51c2637d64ac7a71b0b2dfc45fadb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f8118f50a9f743ccbff4fde80fde07fa",
+       "style": "IPY_MODEL_a1a7b8d967b14f30bb2f6745e4ed943f",
+       "value": " 21.5M/? [00:19&lt;00:00, 5.51MB/s]"
+      }
+     },
+     "bc10550c8441433faeff104eac72e99c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bc14e3b9e2804f66842ada2805016cf7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bc31a351bf214865b2140e5b9ee22f8a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bc540e8ccb3d42a89dd566fad7030285": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ea758de04b2e4d65a72abc73a8c7000d",
+       "style": "IPY_MODEL_dc7f9997345a4621bb50287716722f87",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.Q1.fits: "
+      }
+     },
+     "bc55081950e74871aa6dae7df9bb9e10": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bc7c2d6ff26147feb9e1e27448cae4a2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bc9245fbd05a4b37b95c56dcd1000145": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bcd8580769e347c1aad68cbeb4380ec0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bd03ff7c6be74fd8a1ceece4f6c6740e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b08fa4053c88481cbd74a069780e53fc",
+       "style": "IPY_MODEL_cffeb5b0b97e461ab3db2941027c9f00",
+       "value": " 8.75M/? [00:22&lt;00:00, 5.84MB/s]"
+      }
+     },
+     "bd448efd86884bf383a7cb665823ac53": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_857b5474ebd945f59e9d697914386f9e",
+       "style": "IPY_MODEL_d4ef666748e34e53a32612d221f70736",
+       "value": " 19.2M/? [00:16&lt;00:00, 10.3MB/s]"
+      }
+     },
+     "bd5f247686e44f028d70f6b200ff265e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bd6faffd34c54287a63f3edaf24d8087": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bd75dcc69faf420ab60e9944644e6edc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_96d1239d88634bd3aa75d3558acebd3a",
+       "style": "IPY_MODEL_96cc042c76414be3bd2afc9077b04857",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.src_grad.fits: "
+      }
+     },
+     "bdb24d1f922849d593e1f91d94b2bdf9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bdc45ce54ead456996692d131882de6b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bdc52a87c0164f9396dc2ca4726d4421": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_62dbb41e6d31423b99fcaa638a71d1b6",
+       "max": 8755200,
+       "style": "IPY_MODEL_f926920e8a074e088913a95d5cc469fd",
+       "value": 8755200
+      }
+     },
+     "bdfd9d1f4c434318b0569e103f0f5397": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "be51cd57adea4f67a4b9d855ac588a10": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "be56017028664290878f49bb62cf7213": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "be86432c03d84bac81b00c0470ff649d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "beb8c31ab55e4de4bdcb61ad11e2dd13": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bedf824a9be04ef5b5cae09db8028690": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "beebd9215d784c6d876a99df24c2e323": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bf42ab4455964fb79afdf1774e62b470": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bf45f4f28349449ebb39d76412bd28f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bfa85e9e2eac4da0aeea8992ddf4a15c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bfcd252b633948fdab579ea1ce9ca49b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bfde98793f6647c5b6085309eb6acfed": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c0421924b1c944d8bd01383200528bb4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_eba750e5359d434e8bc7791194104ef6",
+       "style": "IPY_MODEL_b327b900b7fb4889b4138beec7dee95e",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U0.fits: "
+      }
+     },
+     "c0c51168bc77491ab87cbbf7d02c6cb3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f8cc32cba30142c7be86a796be005d00",
+       "style": "IPY_MODEL_c139ca02c4934ac09e11860a5c8e2744",
+       "value": " 48/48 [01:24&lt;00:00,  9.57file/s]"
+      }
+     },
+     "c139ca02c4934ac09e11860a5c8e2744": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c14b44a6afaf4bb4ac41022ee46eb448": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c14bd93f44ce46e284a3f60ec0e7861f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c18cd1917e1842978a09825b4dcb71c0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_d083c603145741d3a5bc5edfe288c98b",
+       "max": 8985600,
+       "style": "IPY_MODEL_5da72991f2b444409ed64ad69951c717",
+       "value": 8985600
+      }
+     },
+     "c193906b54c4436f95a189fe41addf19": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7e1783a9372b4f7b95ea8973718185ef",
+       "style": "IPY_MODEL_6d89289c453d49188c0e7d4c58a050f9",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q2.fits: "
+      }
+     },
+     "c1f0a0303a0f41be82fcd002b5cc201f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0dd2c8bdee114cf3bd5c78482ff673d1",
+       "style": "IPY_MODEL_ddf26ddacee945a89dbe052eae865b37",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.inclination.fits: "
+      }
+     },
+     "c2364ecb73494e078e174746408b769a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c261cc16a8b14661a341e99c5747385f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c279809e671647048c32e0aff60e2c6e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c298961a12e44551891bbb42c0e936f0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_71f4c85b2db54b0c90d2e9797040335a",
+        "IPY_MODEL_fd61430bef6f48378c32963ac9995215",
+        "IPY_MODEL_d65a9cd19a3a4781949e877ce3c70637"
+       ],
+       "layout": "IPY_MODEL_851e114a42c146d48fc3bd00896619d9"
+      }
+     },
+     "c2b7aba8f150401a8b422f8a11e6a709": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_44c33e195f704d13acdee5fdfdcec65c",
+       "style": "IPY_MODEL_9bcbd93c978c45c0b90c2b525c8249e9",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.alpha_err.fits: "
+      }
+     },
+     "c2bb44d18d194a1e9fb66763f63bce46": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_8b7909dd5d854305b18d726b1407a326",
+       "max": 25,
+       "style": "IPY_MODEL_973dfc3a15f242c1b3ab5ddb03ab2131",
+       "value": 25
+      }
+     },
+     "c2e0e8d10f2148b1b079851bf77fb73a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_33db5ac8b8e945bab82016f9df58353e",
+       "style": "IPY_MODEL_d3f6a93e38794772ab9544636e9301ac",
+       "value": " 15.2M/? [00:18&lt;00:00, 6.08MB/s]"
+      }
+     },
+     "c32ebc85c9ee4b77b739bfa2fcef4ed4": {
+      "model_module": "jupyter-matplotlib",
+      "model_module_version": "^0.9.0",
+      "model_name": "ToolbarModel",
+      "state": {
+       "layout": "IPY_MODEL_5f3e9587f5974b52abf991972397ac1e",
+       "toolitems": [
+        [
+         "Home",
+         "Reset original view",
+         "home",
+         "home"
+        ],
+        [
+         "Back",
+         "Back to previous view",
+         "arrow-left",
+         "back"
+        ],
+        [
+         "Forward",
+         "Forward to next view",
+         "arrow-right",
+         "forward"
+        ],
+        [
+         "Pan",
+         "Left button pans, Right button zooms\nx/y fixes axis, CTRL fixes aspect",
+         "arrows",
+         "pan"
+        ],
+        [
+         "Zoom",
+         "Zoom to rectangle\nx/y fixes axis, CTRL fixes aspect",
+         "square-o",
+         "zoom"
+        ],
+        [
+         "Download",
+         "Download plot",
+         "floppy-o",
+         "save_figure"
+        ]
+       ]
+      }
+     },
+     "c347b3217026453fbfcc5fb323c78945": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c39434aa6b974292b6a96183a56ed2ee": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c3b74b52354e4f0da5434a61c782cab6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c3bfa99ed4d24a6bb0908780b9dd5397": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_0a5e1be9c4354d5eb992ca548fc98e14",
+        "IPY_MODEL_4b118aefe05340b39e0a311ecb93aaa2",
+        "IPY_MODEL_b4be6bcfaf1040f4a2cfe607e0824433"
+       ],
+       "layout": "IPY_MODEL_f65a94dbd090405b95b463c85e4e4035"
+      }
+     },
+     "c3df8e0bbc934abd98e8e47540f3209e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c3f05fed3aa542a68a486bdd543e26ab": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c46c88160786440da4bc96806839e677": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c4941bc4b4bf48d5ad233511c84e6615": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c49d2c1fcdc44d18b4551ae68c4f4ad7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c4f7475a51d84b528ac55674ec6fe9fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c4fbdcee682a47928ece124fed9d9636": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_42f8c9160cc54636a2037d873432aff9",
+        "IPY_MODEL_dd00d3f36b7a4dc185587231243c8aa6",
+        "IPY_MODEL_6b2ac75139d1400693076d7163e574b0"
+       ],
+       "layout": "IPY_MODEL_56120591c2a84149abf7011f6c478a68"
+      }
+     },
+     "c4fc0d15e12c47d4b4b890c8710d9396": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c5159c8f64ae452ebfbcb2261744c476": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c5188477bf29481c92c77f73cd4cda4d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c51f1d696f934e219753025d0652f146": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c535dd3f933c431abaae76d7bebce102": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_51fd94438216474cae8f7f9e39d7245d",
+       "max": 14137920,
+       "style": "IPY_MODEL_da2f675b53c94f0da26761a5463033b9",
+       "value": 14137920
+      }
+     },
+     "c5636ee83ef34880a9676b038d230fe9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c56e0f15664140fb9371369b74062a64": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1036b59b8eca4a2c8c56b8dac7359b34",
+       "style": "IPY_MODEL_97355e9d737940cd902a8fe33783026c",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.damping.fits: "
+      }
+     },
+     "c5a4fff3e6ba4673acb4d45a7d831934": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0463a83eb1714487b2a001586ba6b174",
+       "style": "IPY_MODEL_a0ee08d99716462d942823d16e571707",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "c5f44d58dad94d45aa7c12eed9aefcea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f7cca1a3bb714936b72246d12ee17ca2",
+        "IPY_MODEL_807b053ef994481190bc2f9e7135842f",
+        "IPY_MODEL_9521020276e94583ab7205d53be491f3"
+       ],
+       "layout": "IPY_MODEL_3c0878b98b6747ae825c0a290a7ff4e4"
+      }
+     },
+     "c60c77b1484d4774bd25ac59336ab384": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c61b0a97dc2c4dd2958165cacf180d02": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_dd0ce9581c2446e28e4a811448427eaa",
+       "style": "IPY_MODEL_77630769ecc84653983b05ed096395ec",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U2.fits: "
+      }
+     },
+     "c638d10b9aae4b6998144c2e2a3343c1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c6e352e0a5e2447d8b974864b67c5128": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1e2b380bd953485dae84c44f408f59e6",
+       "style": "IPY_MODEL_6d1ab58a8e3e431c8fd772358242686a",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.inclination_alpha_err.fits: "
+      }
+     },
+     "c70b3692061d4bd694ab9c3c902872b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c71b1c1f9d55454ea5bff6986d7f1767": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c730cdbdfc894b63ad75eb8057f67177": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c735f61d4da6461092e78ac68fe082ae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c74ddc0486fc46f98e12e930697ce203": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c74e49e3a0f5409db766d61bac2e2bff": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_72b379dc310543958d0b4384f1658bba",
+       "style": "IPY_MODEL_0ffc6ee658c6417ab6cc583525af82c3",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.eta_0.fits: "
+      }
+     },
+     "c7a06b03efaa4342860a7eb10b92e140": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c7d53bb55bbd4d1884c2cf27022ae775": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c7d6351fca014bf09ea78782eedd1328": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c7ea66fff7234ce7bfd010f24752b3ee": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c8063c35227f466d805665e51333810f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_714a67c438284ce48f7c1bc37655ea07",
+       "style": "IPY_MODEL_7d8213cf791f480fac70f36dfcd77932",
+       "value": " 14.1M/? [00:22&lt;00:00, 6.60MB/s]"
+      }
+     },
+     "c82cff25208d487baa84ad04bf30d3c5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_253013e9e1b545e5889c67682a15bf74",
+       "style": "IPY_MODEL_dfb1d1b97b104e8685973a0724bc6472",
+       "value": " 2.90M/? [00:18&lt;00:00, 3.14MB/s]"
+      }
+     },
+     "c8441aee3f614443b0297c82baa1ad2d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cdb16620f6264f539164ee3d81ba98b4",
+       "style": "IPY_MODEL_f8022c03ebd94e53825ee25d58ad3e9c",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V3.fits: "
+      }
+     },
+     "c85b24784bd5498eaba103eff6b2d4a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_74a14f1c7fe74d059528e95e12c51ea6",
+       "style": "IPY_MODEL_dc94e17a825f4f1a8792069ad00bdc4a",
+       "value": " 50/50 [00:04&lt;00:00, 12.53file/s]"
+      }
+     },
+     "c85fe0328c4341b890196e649c1e75f2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c886ff38cdea41d297b6f8b39b807675": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c88ebb6e3787421187cf87aff6236307": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_14cbf02706cc4f258b00d11d53fe05ab",
+       "style": "IPY_MODEL_aa9690a664704411bf147efcd32d3bc9",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.src_continuum.fits: "
+      }
+     },
+     "c8d4c52a8eca4f53be308cade01a85cb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c8e9c9ff680340599f1c81d63654b302": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d0061e07b0a9436f912ba960648bf4d4",
+       "style": "IPY_MODEL_0aaa65c71b924998a0fe4ab46538ae02",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.azimuth.fits: "
+      }
+     },
+     "c8f4eb6e0ebc4e04a73a6f50ed16c02b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c96d8bc12610498d9e11b634d604c202": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c98f293241c84c6f893931a579c69ddf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c9c0e8d2da0a44c689c5dfc4d2c1ae70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c9d52df11f964fdaa8a0bfa482dec496": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c9db5f71a0ec4fd39167ee0e50a9b000": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ca0a73b63a984714b755504f09651023": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_79068570764547c3b1a3ea472d62df72",
+       "style": "IPY_MODEL_cb554309f3bf4a1096141a709949e03e",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.confid_map.fits: "
+      }
+     },
+     "ca48dce856174b9ab66cb68ca8980980": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_d9b412b762bd4486a1ddb50e50c60d5e",
+       "max": 20448000,
+       "style": "IPY_MODEL_ed9e5ce696f644c5bad9b4540c792c3f",
+       "value": 20448000
+      }
+     },
+     "ca513d68a6984a0983049e8aa5f89560": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_79cc6511a68f427a82bd78d3a9d66b58",
+       "style": "IPY_MODEL_a9494e29b8884e0493f22ddcb951ee3a",
+       "value": " 24/24 [00:01&lt;00:00, 12.36file/s]"
+      }
+     },
+     "ca5f97184b9648be990d48e4b5da9552": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ca8b750f23ba4477915fbba2bec8bf63": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_117ae5b31e314abe80551993b85e0c02",
+        "IPY_MODEL_cfa28ad54f5d40a38c893afd0e70037f",
+        "IPY_MODEL_2d6ad1d66e5240bcbb6923615b2e5325"
+       ],
+       "layout": "IPY_MODEL_5a175b8c9776432ca5428779d88b7f59"
+      }
+     },
+     "caa99c9da9424f40888aaa3a5b30fb48": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_254d0e83768a46a7ba5a1890614872c5",
+       "style": "IPY_MODEL_672240362d91489a8c61a539cf39825e",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.vlos_err.fits: "
+      }
+     },
+     "cab15de1f5fa4478bacfea336b70517a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cafb05d96ebc48ff9dbe0e7b5bbdd56c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cb0c0eb05e4f4cf5a7e7d2e7edb5a63c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cb4b347c19cc4326b1a6aa455bdcce59": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cb554309f3bf4a1096141a709949e03e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cb5caa4e6e504013be4a74d62e95476b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cb6344a214744440a9e1869c86f6dc3e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cb94e8e45e564eaf84ab546d9f6349b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_17670e81ceb749e89dcbc9ed3d052fe1",
+       "style": "IPY_MODEL_d69f1538391f446e9dce24b9e7ebc662",
+       "value": " 20.6M/? [00:16&lt;00:00, 5.57MB/s]"
+      }
+     },
+     "cba2e1cbcca447d494e9c0ea20e2be28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b98268f8aaa94faca5f851a2b6b9fe1d",
+        "IPY_MODEL_103ffb55a90745e691e95d922ec3c1a7",
+        "IPY_MODEL_9a841c0af1b54dec96af951a3131a4f3"
+       ],
+       "layout": "IPY_MODEL_556bf9195ae74fe2b96665ee61862dbb"
+      }
+     },
+     "cbba9130ebe245e5b78ae992c759a612": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3b814a307ae1476d996538ed6edef925",
+        "IPY_MODEL_eea9dba4f8a2409da8ca72328eabe0b2",
+        "IPY_MODEL_e06c90bc8fb446c09593f1220d124977"
+       ],
+       "layout": "IPY_MODEL_84cf45c227ae4fddaef0fa6fa7f0d09b"
+      }
+     },
+     "cbe62281a786431483542deb534acd3d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_73e3e29c13744404b9f9ef8d15110d0a",
+       "max": 14702400,
+       "style": "IPY_MODEL_9a49b9a9c35e4368a02e2ec0c24e5f14",
+       "value": 14702400
+      }
+     },
+     "cc756d24c7574d6786d207ba7ef502c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f055070b8a1a4f83854c488b99bc7b30",
+       "style": "IPY_MODEL_fcc6ce6c346745f49a77febe3f73b4a9",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V5.fits: "
+      }
+     },
+     "cc792b696bc54232a2f01f1df6c812d0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cc88a422ea204ddb97c4a6eeb78abcee": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_6551920c57c74a9598dd518b675a1519",
+       "max": 7960320,
+       "style": "IPY_MODEL_d556ef6366ea494b814e2bf0ee107046",
+       "value": 7960320
+      }
+     },
+     "cc8b63c6aa6d43108b4bb89c17b7e668": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3eeed23833a24bfaab4b20c2fe6776af",
+       "style": "IPY_MODEL_7b94a99a5d174acaba530f1cd0d25784",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q5.fits: "
+      }
+     },
+     "cca2ba193148406988a70188de67ad88": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cca6cd31aa214c5f9a4197f32abd8846": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ccb9eaf17e554cf89071ab96cd0bf24f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cd0e5f878fbe444da98cd1e27b5990ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cd4052185e7348ff9654ca94a2ac7cde": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cd40d57d576b4c44b2b3bfab3f657fe8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cd82ea41bf2245ec9e183f0533ee5839": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_aa0ccb24db7a42168e3587f7f9575feb",
+       "max": 24,
+       "style": "IPY_MODEL_3339b8ec4b5a410e910fb07609430fa9",
+       "value": 24
+      }
+     },
+     "cd84526c4dd044249e879015b7743cc2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cd867370fd2d4672a3b7480bc16df8c5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cd99e901a3c946709e62f79f23fc850e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cdb16620f6264f539164ee3d81ba98b4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cdbe7428e42e4fb78541fd27700b2698": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_db2b6f333e4546d7af598764a17b9acc",
+       "max": 10402560,
+       "style": "IPY_MODEL_7bd1608b64ee4449bc11087e3b111698",
+       "value": 10402560
+      }
+     },
+     "cdff8f2483e2470dbca94cf5c00c7956": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ce025f63db23454085092611bbbe958f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ce047f67f3ed43719a4499579813d3b3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ce287526464646ed8f367d37b97039e7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cecc4ebe600a43a798b9fc3147034c93": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cf0597694b41414c8ca9ceb8aa9d3e3a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cf05e948590543a19631ffbf62591997": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cf4f71e000f544f8884fcd0bd948e759": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cf6d35214f064fef81436a08abaecb30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cfa28ad54f5d40a38c893afd0e70037f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_b75838ff5dbf4f0baf6cbee721b1977c",
+       "max": 22800960,
+       "style": "IPY_MODEL_e826237e982d4628a8069f4734380657",
+       "value": 22800960
+      }
+     },
+     "cfad0cddcd644c5197999e19d5a64628": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a47729ff93af47879d78e4a4be0ccfcc",
+        "IPY_MODEL_5868f343e2c04520884e4663ec82e247",
+        "IPY_MODEL_e7f1084a0c0a460f837d7025baf0eee5"
+       ],
+       "layout": "IPY_MODEL_c51f1d696f934e219753025d0652f146"
+      }
+     },
+     "cfb4f4ed18d44bbcb871d7ac8392a0f3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cfcbba3b17f4478cb974717a3f639c56": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_919ce1abb7424d36bebd7860d03ac1ac",
+       "style": "IPY_MODEL_f3c67c4b5434443bba98cca4f8f77f1e",
+       "value": " 9.71M/? [00:14&lt;00:00, 7.27MB/s]"
+      }
+     },
+     "cffeb5b0b97e461ab3db2941027c9f00": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d0061e07b0a9436f912ba960648bf4d4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d010657b84b44f188b241b741e6a10e9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d01a1de15a2642a6989235866c03cb86": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_e2391072a7ae49b39bde1bbe64a55385",
+       "max": 7977600,
+       "style": "IPY_MODEL_ee52e67b69b54ffab1840700dae9ddc0",
+       "value": 7977600
+      }
+     },
+     "d046c575407645f19842c50506a2e417": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d04d5de9f75e4aed9d111765dc3163ad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d064242f178c498ba07b9389d7e31de3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d06a94f0600d4841b1bd1041eb33cc05": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d08005cb3a84463393ff316ac110bf34": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d083c603145741d3a5bc5edfe288c98b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d0919fa18f4b49378d60c28b8cdb3173": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d0ff9af534b84bcaae26988a7c5c3c73": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_f7edb6ac6f3e40a19692e130f19cf44a",
+       "max": 14702400,
+       "style": "IPY_MODEL_7a75343a1d1d484eb2e3067517b5a4ea",
+       "value": 14702400
+      }
+     },
+     "d1004b8aea7c437b83647b1468f47f4f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d10e5ccf45cb49ca8c57e5103a0f981a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d160e9c2de5f4051bfb6aa87e04cf20c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a959cae44be0495bbf034aac1e3c7571",
+       "style": "IPY_MODEL_2a79ebb392034a03be46ae95faa299a8",
+       "value": " 1.35M/? [00:20&lt;00:00, 1.65MB/s]"
+      }
+     },
+     "d167c9d974a84cb5bf0b7c26f95c4ec6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d169a023f32b4c34aef737c594bdc226": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_21a37622a97e46d3befb65bbca285fe0",
+       "style": "IPY_MODEL_bfcd252b633948fdab579ea1ce9ca49b",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.I2.fits: "
+      }
+     },
+     "d188c8eeca7b40e1878b08912779863f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d198ee8cd3b24b8fb1cc6b6e7ce4766d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d1f24d1251a648dfa3e52ff15b1beab9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d213a2f7ef7d4698b360068e27ae9655": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d252d15f1fee40a2a85506f04bf88997": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d264d6f7c84c4959a47f20f75d0f23d6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d2715076b7d84dff95a50ecfcb2d945f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2885d1d249ae476ba8f5caea2db496e5",
+       "style": "IPY_MODEL_4121115e52574db5851fc8e496fb6086",
+       "value": " 9.61M/? [00:14&lt;00:00, 5.14MB/s]"
+      }
+     },
+     "d289dc24da7545428e3fdc43e1f4f301": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d296c88bf0cd4b8e91a530f2835a9a73": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d2b5385435bf4f06a829e84ac0fe77ff": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0b5c01826aa34133a8835793e96c6094",
+       "style": "IPY_MODEL_4e745d4c80774f4989bf1defbd6d7147",
+       "value": " 24/24 [00:02&lt;00:00, 11.92file/s]"
+      }
+     },
+     "d2dfcf82f3484088a7ea535bd526b2e5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d2f82eca7f0742aaab9597d92e735049": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d167c9d974a84cb5bf0b7c26f95c4ec6",
+       "style": "IPY_MODEL_97145877d6cf4213ac1ef6f4d18f4d9f",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I0.fits: "
+      }
+     },
+     "d337a66780724300a07795a321f7b31a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_732060790b094e99a1eda3483fc0f952",
+        "IPY_MODEL_fa891b81f28a4dd88c387af66f0ec252",
+        "IPY_MODEL_963d95194cf441529ad68d1f93ae3c65"
+       ],
+       "layout": "IPY_MODEL_39d492aef3a44308ac5cc55d3c0959e2"
+      }
+     },
+     "d353947c9c4643499d2554d7617b6dae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d3658a7f91bf48c28a630425eedad105": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b726ddecb6434987bf227778d565b2f3",
+       "style": "IPY_MODEL_137e664e7e2149d4ba870fb4fba64563",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q2.fits: "
+      }
+     },
+     "d38c2fe969cd4e8cbb25bedf246a700c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d3cc6d7e102341528cf2021cc2d4a8d3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_99a110139eee462188958efc8a454c76",
+       "max": 24,
+       "style": "IPY_MODEL_2b55e04a16b5475686e262eef900f2bf",
+       "value": 24
+      }
+     },
+     "d3f6a93e38794772ab9544636e9301ac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d4231f0cddda496e811cd18204b0a6e0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_238025ce083e49649b8991771f1d1a3e",
+       "style": "IPY_MODEL_24591296619845f8aad159dd9ec00087",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field_az_err.fits: "
+      }
+     },
+     "d4235c0cab3649b3ae010b4b6859f498": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d45ff76970d047afa859211feefc5f35": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d461d5a85ed84a08a55b47d112cda965": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f069330ddd2c442388cb613909dbd727",
+        "IPY_MODEL_f3ede3ea67634e32a9fe777df8290271",
+        "IPY_MODEL_05af202bf9cb400b8d2351779caa2701"
+       ],
+       "layout": "IPY_MODEL_8c26834f09824f35be89c0d5a2b44526"
+      }
+     },
+     "d480ff6526574b43a01a5ba0a3dd053d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_136a5f65dd0749418e739a7ad37839b3",
+        "IPY_MODEL_9becf18b9fc1499187796a604d0a2ed4",
+        "IPY_MODEL_2458132c3a314ffeabdaa62cd71afee1"
+       ],
+       "layout": "IPY_MODEL_1354b41bec3b408690514d004265e221"
+      }
+     },
+     "d48a0649b4d0472aba2e01cff8c44188": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d4d1931f7f404067ba916e7c28bebcb0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d4ef666748e34e53a32612d221f70736": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d5077abf998a4dcaa4d162468cd437be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_051065ce87de478aa89a73eebafe5e7d",
+        "IPY_MODEL_3223fa83d9d24ac294ef6416f3f34962",
+        "IPY_MODEL_b6409921693d4861824fa6aeb4937700"
+       ],
+       "layout": "IPY_MODEL_4de307f947f14a39b51080ffdc9fc675"
+      }
+     },
+     "d509c710c7c94440a8f869ffea2927c6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d525ce4295204549b64b83748a88256d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_ed49234b9f4645299b4e180388231941",
+        "IPY_MODEL_39133619e9474f3bb8d2a5a0b7029ee0",
+        "IPY_MODEL_1e7cce1b76484bc39f3a1c0440f0f346"
+       ],
+       "layout": "IPY_MODEL_47c83dc3f0f7429dac2cae5df2c5ce4b"
+      }
+     },
+     "d537959166034f7ea8de69c3ce58988f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d53f11b9e275432e817e0e98ffb8c5a6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d541fa821e74413aba6beb82c29a4aaf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_86f8aab4dafe4b85ab7f124af6759719",
+       "max": 9607680,
+       "style": "IPY_MODEL_846841aff85c444e9e2ee0822d072f3a",
+       "value": 9607680
+      }
+     },
+     "d556ef6366ea494b814e2bf0ee107046": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d56b485c544e45a185560528dd7a6d83": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d56cf033588f40e9b89128b19f848b14": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d5c39d7b26084eacb666dd9c71459d8f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d5debb73ad4341bfa2c2656de76aee10": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d605ab6e4175446bb765c65a1ab05de1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d65a9cd19a3a4781949e877ce3c70637": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_56d73412e67a4158b0fae1a5d1c2d896",
+       "style": "IPY_MODEL_04f0fd8b8dbc449e8de35892c07efd14",
+       "value": " 9.70M/? [00:19&lt;00:00, 4.32MB/s]"
+      }
+     },
+     "d69d7fe8312a4438b819da76f426e78e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d69f1538391f446e9dce24b9e7ebc662": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d6c9a08e03654e89a68593b53393d177": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d6d3cc22eb9e430bacd388db972f1b87": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d6f4d44e16bd43fca98bcca0c5027ce3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d73e5a733b684ce8b46fa19cfe8a9bfe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d7434f40ca564493b23068c47e1a834e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d77272f74cba4e0aaca5a804d59c352d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d7843d0997794a46a51ffdb7a4237298": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d792f653a8e74d8b945b67f24539082b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d509c710c7c94440a8f869ffea2927c6",
+       "style": "IPY_MODEL_193ea3aaea7c4af98099e004f14e330c",
+       "value": " 9.33M/? [00:17&lt;00:00, 4.36MB/s]"
+      }
+     },
+     "d7d09ec458fa4cc7ba0447ab9015df4c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d7f1596cec634975b640029c58521884": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_68b83e5ecef74be79237fecb4c23ed30",
+       "style": "IPY_MODEL_32355910c78c4c51a090543f67603672",
+       "value": " 9.73M/? [00:12&lt;00:00, 6.29MB/s]"
+      }
+     },
+     "d80614d16a994f5fbb9be99d363d4eb3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d818c157b27a44f2b3709038802f34ff": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_16c7a54018f14e0c8ec57a4a80062487",
+        "IPY_MODEL_e941511983404338861b9e8e54ef354a",
+        "IPY_MODEL_b391dcd0786b45a69da040cd3c1fece2"
+       ],
+       "layout": "IPY_MODEL_125bd89b2d0942658e48a2a7851eb45a"
+      }
+     },
+     "d82affa3f89c42b9a6528968bd62d0f0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d85c090b222744bd9e958149b86cc8cb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_2d838ddae0f64d8aa8f99cb66c812fc6",
+       "max": 9696960,
+       "style": "IPY_MODEL_c96d8bc12610498d9e11b634d604c202",
+       "value": 9696960
+      }
+     },
+     "d88e79d9b8cf4f76bd59ba3d7ec9115c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d8dac80bc91e41c59c232e9bba1adaf3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a4429034e59e47999c177a82972cfd8b",
+        "IPY_MODEL_bdc52a87c0164f9396dc2ca4726d4421",
+        "IPY_MODEL_e94bc9a8e8254a86a0bcb18dbe0dc232"
+       ],
+       "layout": "IPY_MODEL_3bc5c2cb4ff5438dac591481423be230"
+      }
+     },
+     "d8f6e138688f4140a3516dcb463f25fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c74e49e3a0f5409db766d61bac2e2bff",
+        "IPY_MODEL_6126fce3d25e4a7b90b4d79c2b922569",
+        "IPY_MODEL_681db60066ab4623b50631c64b9fb997"
+       ],
+       "layout": "IPY_MODEL_62924c4aff014faf9eee8219bb26e10e"
+      }
+     },
+     "d904327e71734a48ac701f1e4a5e2e38": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_bbf0de444f194aca89df3a0dd124738a",
+       "max": 9204480,
+       "style": "IPY_MODEL_34f9f5aa466649f1a1055fffd7b97cbe",
+       "value": 9204480
+      }
+     },
+     "d9106af7d5354aabad00842e2ce68a6f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1c1d06facea84a64947caac815c8c9fb",
+       "style": "IPY_MODEL_594c0359c02946f19c287eda5cda0ecb",
+       "value": " 8.66M/? [00:15&lt;00:00, 5.87MB/s]"
+      }
+     },
+     "d93ab3ad7f7a4b659eff51d6fae97725": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9251bcadebcb4fc38c1a497298c1675d",
+       "style": "IPY_MODEL_a62e3d6bdb7b42589e758a6526892305",
+       "value": " 9.55M/? [00:15&lt;00:00, 5.56MB/s]"
+      }
+     },
+     "d96a1786a94647a8aba6635fc6f8c7a5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_0fcbddc8f07941139840873899f14a25",
+       "max": 1353600,
+       "style": "IPY_MODEL_f3b91e8ac7824abd824ca1fcce035b82",
+       "value": 1353600
+      }
+     },
+     "d994f57f351c4728942c813560299f5d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_92d0a6fb24994a7a8773b727b48084c2",
+        "IPY_MODEL_13277c907c6d4a68af5fce735103e8d1",
+        "IPY_MODEL_e01bae4a92c94cd98378913d5a5162f3"
+       ],
+       "layout": "IPY_MODEL_6c975854b0ae48819c62ab64152f82f3"
+      }
+     },
+     "d9b412b762bd4486a1ddb50e50c60d5e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "da1babccc6a544e5a2c44d72c2651319": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6fb3ebdc75784e7ab6af11e45ee2a823",
+        "IPY_MODEL_286360e68e0840b2bfac1617e31ee2c1",
+        "IPY_MODEL_fba60fd6486447de9d8981dabcd8f1ed"
+       ],
+       "layout": "IPY_MODEL_ee5e55cff27442a7b1cd8993d2fe0c25"
+      }
+     },
+     "da24d8aa1b2a401194659c9ab3c6a211": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "da2f675b53c94f0da26761a5463033b9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "da6c7d47e51342f6bf18e7fff17639c5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "daf9102dc4414aeba00bb4412b8662af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "db1e1e78d81749df983263352b2c4a9d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_bada7034346744419b36a0bf662fde84",
+        "IPY_MODEL_a25abb79cbb74a27b18a46c11d6b05d6",
+        "IPY_MODEL_295cea7e5c6c442a9c61008480aa6d4d"
+       ],
+       "layout": "IPY_MODEL_defa24c3d7be4f7fa75a60d9fc2f0717"
+      }
+     },
+     "db25c47f5814482e89340f143fe7c0f6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_58edbff70397452583fd8bf7600d31b3",
+       "style": "IPY_MODEL_27a0be5c2e6d4746abbbfe21545e306b",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q3.fits: "
+      }
+     },
+     "db2b6f333e4546d7af598764a17b9acc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "db68b533dfa544c287e417a8e80d259a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dbe96a3c216a49c9b6a6c4e81fcc516a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dbf18627af3f445cbfbb964e1eaac9b7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_495a98995757407fbbabb99d69f98619",
+       "style": "IPY_MODEL_7f4ee2c158d24ee4ba44c2afed2c19d0",
+       "value": " 9.70M/? [00:13&lt;00:00, 7.25MB/s]"
+      }
+     },
+     "dbf7de19c9204d5c85af0e01b5cdea66": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dc148c8244714a6fa44a9ebf693e8eca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9ea32a82518e4abaaaa249e1165d2562",
+       "style": "IPY_MODEL_e91f7981b39449b9a6fd4dcce8692169",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.alpha_err.fits: "
+      }
+     },
+     "dc25820f723c4d98ae86ffc9a2185997": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dc5bccc710834d55a8c37c80628f1519": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dc7f9997345a4621bb50287716722f87": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dc8673524cc840048fc5ecd7346b2d4b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_00a14d654dd74e31b0a24dc3aabc12a3",
+        "IPY_MODEL_9ccca25b76bf44fcb66055030e81656d",
+        "IPY_MODEL_d2b5385435bf4f06a829e84ac0fe77ff"
+       ],
+       "layout": "IPY_MODEL_da24d8aa1b2a401194659c9ab3c6a211"
+      }
+     },
+     "dc94e17a825f4f1a8792069ad00bdc4a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dc96cdc88ce041a08476a28052a103c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f26aebd79c044794bcab18e7f8fe3c4d",
+       "style": "IPY_MODEL_0d558a98d11d43d5ac6ab0ca876f7737",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q4.fits: "
+      }
+     },
+     "dc9ef88cfda9498b9ea3b297bd7d2d2f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dcc6ad4cecb2453e8130dad079b9cc71": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_20a14acb51924c11808cce967c2fe207",
+       "max": 9607680,
+       "style": "IPY_MODEL_eb5cad7a3c5d4f3899d18abde066c028",
+       "value": 9607680
+      }
+     },
+     "dcddceb0d9874706bdc80d88eb550095": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8657e2190e684209879ae0c05ada467e",
+       "style": "IPY_MODEL_e8a32a6f84ab4240b3341bab7bbaea97",
+       "value": " 21.9M/? [00:23&lt;00:00, 6.54MB/s]"
+      }
+     },
+     "dce4d80335f249ceb1d14774ab9bff59": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b74f1cb525a64f77a504533158d043a4",
+       "style": "IPY_MODEL_8978033e00c04322842dd7fe8e1c898d",
+       "value": " 8.97M/? [00:14&lt;00:00, 5.50MB/s]"
+      }
+     },
+     "dd00d3f36b7a4dc185587231243c8aa6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_9fc3131e2333462db83c33f9ff0dce1a",
+       "max": 14843520,
+       "style": "IPY_MODEL_742d63f2e241488baacf2e5da00518ea",
+       "value": 14843520
+      }
+     },
+     "dd0ce9581c2446e28e4a811448427eaa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dd0fb0cfe41944d4909879ca610e8abf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dd16336c165c41b794933d2b3cd51531": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dd43021bf7d34bb08d967d38add29951": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ddda4d3a26104903a4060c44aa17a748": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6fbc03ec8db34a4f8940b41654f2901e",
+        "IPY_MODEL_4174cfe2c7504034a1d67059a566ec7a",
+        "IPY_MODEL_ca513d68a6984a0983049e8aa5f89560"
+       ],
+       "layout": "IPY_MODEL_644359e259e14cf682afa06ce8f52c25"
+      }
+     },
+     "ddf26ddacee945a89dbe052eae865b37": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ddf732d622de4bd59cd73ffa1ac91c40": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "de2b7d7a4afa498bb06724f1ff2b2d01": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_31d3de5ca20d440baf8e3f6190ce35d1",
+        "IPY_MODEL_980e0f664f89444dba61bd698582279b",
+        "IPY_MODEL_dfd49699073c49bb8ba40d5d184b6666"
+       ],
+       "layout": "IPY_MODEL_b5cea73c61e34054998f38de02d06da2"
+      }
+     },
+     "de2d3454e05d478db0ffe3dcaa5d8b4a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "de34b7c7a712470a98b288c28173de8a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_a4ee1ba568114f30a1bc230fbc868cf3",
+       "max": 394560,
+       "style": "IPY_MODEL_ddf732d622de4bd59cd73ffa1ac91c40",
+       "value": 394560
+      }
+     },
+     "de80115f4941403c9882121bed01be39": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "de9a24df05eb4d83ba41212c6ecc1374": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "deef0e5287574dfbbd7226838bca0cc4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "def0f690ef2b40db9739882e30430091": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "defa24c3d7be4f7fa75a60d9fc2f0717": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "df619886c9bd42f38b03464d82423ba9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "df67211c71ae4eadbd12aea9b8d2ad99": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "df738f2af4d74bba84bef585686e8d9e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_113872d9cf56436280de63b000f8ace0",
+       "style": "IPY_MODEL_5a2fa5b5d56e4e9089a8294f681a00a4",
+       "value": " 22.8M/? [00:17&lt;00:00, 5.30MB/s]"
+      }
+     },
+     "df772f7545654cb980b9894101f93a1a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dfb1d1b97b104e8685973a0724bc6472": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dfb32f8e63c44ea88ce3953d3121d9ed": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_342cc0a2791d42bdbc29766677ef3da8",
+        "IPY_MODEL_e635d440bba44297866b3a1eadf8e24b",
+        "IPY_MODEL_4aee07cef1354791999ba46df226938c"
+       ],
+       "layout": "IPY_MODEL_c8f4eb6e0ebc4e04a73a6f50ed16c02b"
+      }
+     },
+     "dfd49699073c49bb8ba40d5d184b6666": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b69da738dee441f9a207b1ff81892940",
+       "style": "IPY_MODEL_013dcf36ceca4d4f9e90c8984daa976d",
+       "value": " 285k/? [00:15&lt;00:00, 630kB/s]"
+      }
+     },
+     "e0167755e2004576b359a792eea80619": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e01bae4a92c94cd98378913d5a5162f3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ad143c5690cb476ab79da0ead6285558",
+       "style": "IPY_MODEL_4601b367827a43f1a10e1a73ff8c92fd",
+       "value": " 15.5M/? [00:14&lt;00:00, 7.41MB/s]"
+      }
+     },
+     "e03026454cf9442b806d89fe9405e648": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_36c87335180d4e609e2aa2e57cb132b4",
+        "IPY_MODEL_6fc7d02e92444a7b94702f085d4f192e",
+        "IPY_MODEL_55ea70d56b9048f19e7185abb609e004"
+       ],
+       "layout": "IPY_MODEL_728d6fa2fa5546d18bed2a3c13f763de"
+      }
+     },
+     "e044d9c82a9a4867919d5fb421915022": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_30e7e9943ce3492aa3199e72b4e94894",
+       "style": "IPY_MODEL_9d9d979ac33a4a16900a1959888cc3a7",
+       "value": " 1.35M/? [00:11&lt;00:00, 1.84MB/s]"
+      }
+     },
+     "e06c90bc8fb446c09593f1220d124977": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5c3746f019eb43a1b32318aa8618780e",
+       "style": "IPY_MODEL_6343dd8d14d7476b9eab384b72f29b59",
+       "value": " 14.9M/? [00:17&lt;00:00, 6.14MB/s]"
+      }
+     },
+     "e1021c0886cc4292886f3f4522b8197a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e13418fe6a3443dcb41b9a94551a3ac6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e1b812d079e945599a4a468032d539d6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e1be240889f34a43a132d70475705a8f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_86a003d0d5174a6ba99998add6aaf9de",
+       "max": 8732160,
+       "style": "IPY_MODEL_ac1c64e4c5444192b7a3d312b948e39f",
+       "value": 8732160
+      }
+     },
+     "e1d58d007b0242e498ee64709c6e5595": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4160af87c89341ecbc4b9737ae552411",
+       "style": "IPY_MODEL_805dad429fea44929f69e1b2d73b9bb7",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.field_inclination_err.fits: "
+      }
+     },
+     "e1e0fc57ca1744cc886a364f33a4362d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e224d122f6904711a66e61106c74e145": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_106f9ce01ee04a328bc1a0aef92555cb",
+       "max": 14705280,
+       "style": "IPY_MODEL_4db4564dc79f47f0a006a0963929babb",
+       "value": 14705280
+      }
+     },
+     "e2391072a7ae49b39bde1bbe64a55385": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e248e49c77e34813a0b9eed3e7d91bfd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e260e3e434b54c0999410ce77a0b6305": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e2757ecde8974e7eb4266b92ae2e4743": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_b7dda19a1a974829abd461b96613b1f2",
+       "max": 1353600,
+       "style": "IPY_MODEL_be86432c03d84bac81b00c0470ff649d",
+       "value": 1353600
+      }
+     },
+     "e2a1490c4e9c4c97812658c3ef6c62a5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e2bd0bf60c034589b9783d759649ea9e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e33a3623015349c796f14de8d498b083": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_3e2181d0bd7a4962ad16b9d110434905",
+       "max": 9599040,
+       "style": "IPY_MODEL_23029e56c7014015ab9e41341fea3a8f",
+       "value": 9599040
+      }
+     },
+     "e35554a7de11468abbf75e8b6d2e2ed3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e375c9043c6a414380b44a5cc8b07020": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e3b871fc2bee4c86a476bfc8c0d999fb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e3cacefdac604eb5843cb7649ce37a5e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_287a56d72f4a4742a0e804397db01c5b",
+       "style": "IPY_MODEL_558cc6e0c160457284bc4ecef5d81243",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.field_inclination_err.fits: "
+      }
+     },
+     "e42710b83bd64f2c9e6fe3ad99b0f353": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e492d50cedbc4b0794c232d4b102c6bf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e4b390adf19047a895960768ff76280b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e4bfc44366504bd9938844d770d22fa4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e4c2cb82ff5d4cdaae83cca7419466b9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e5278e37b1594f2f99504350cc512430": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e54a826f38e94c51b9b0236f6d643862": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_31a43f0eb81e4c2a9a0ced0847363dae",
+       "style": "IPY_MODEL_adafe6bceb8141f6b037d2380a07dde4",
+       "value": " 15.2M/? [00:15&lt;00:00, 5.78MB/s]"
+      }
+     },
+     "e58df4a0f21642fb9327de2ab84de9aa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e5c0bc1581dc42d69cd5eed023a8a3d2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e5d0318667d44b06b7e3b2f36a9715ba": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e5d7bbae5165478aa7eae668bbf29f92": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e5fca260629a43eabae2f4438e65cbd0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_38c6a0c7b503473bbf991e9d5ba83eaa",
+       "max": 8657280,
+       "style": "IPY_MODEL_3c50c2a35e3e424595d9b97e477d5f55",
+       "value": 8657280
+      }
+     },
+     "e60366dbd7e84d5c9c943e1a585307bd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e635d440bba44297866b3a1eadf8e24b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_803593ab397046d9a440666aa1631097",
+       "max": 394560,
+       "style": "IPY_MODEL_cd4052185e7348ff9654ca94a2ac7cde",
+       "value": 394560
+      }
+     },
+     "e67890dc60b14c3cb57271b8e42f58f6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e6c3d4d45c5c420ba66badf44cd1aed5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e6f09f0103da44829d11dc10c15c89cd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e6fcae3e5ab244139d717ed3a57a5b53": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e714b14ba4d9451f8b2c93fdd0e94ed5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e79cdbf39c844f1cab664881c64db653": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e7bbb674094b42f7bbdff8ca9d79bc57": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e7bd0cc18bad40d1843878735fcde885": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_45a1eb77a73449a2ad9efb2b6451f09e",
+        "IPY_MODEL_eba26c13d330498594beb113e88b0bab",
+        "IPY_MODEL_991ef6f0faea4f2293550d042bf32457"
+       ],
+       "layout": "IPY_MODEL_a71ef0e47bb741b9b926cdf66e9377c9"
+      }
+     },
+     "e7d82ef7c4b34661a7b3976952a3e155": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e7e51dfc6d0745efb9f781ed2cd3cf2b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e7f1084a0c0a460f837d7025baf0eee5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7d3a4339aa3f48968b91d878c4b84fa9",
+       "style": "IPY_MODEL_fd05e523c1e04211b91502ccfc6df98b",
+       "value": " 9.71M/? [00:19&lt;00:00, 5.09MB/s]"
+      }
+     },
+     "e826237e982d4628a8069f4734380657": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e87b4f0b9d8346bda5b144f22d92d27a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_722f00bf361743c9be237e1097fda2f2",
+       "style": "IPY_MODEL_b518db24c9ce449bb84b73ac83dc8276",
+       "value": " 21.7M/? [00:18&lt;00:00, 7.85MB/s]"
+      }
+     },
+     "e8a32a6f84ab4240b3341bab7bbaea97": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e8bd70fedcb04217990b601548fccb5f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e8c60f2ec8a748aebdff4c8a8775e3b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e8e1d80050914499aa4e93067ca20fba": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e8f0d6f2a60e4c7fad48923c5ef0dd50": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e8f6b2dc8c20449c939c69ffd2eb0694": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c56e0f15664140fb9371369b74062a64",
+        "IPY_MODEL_1bada12a195b465db35fb804e0a649ea",
+        "IPY_MODEL_1caf0d6b9b2149f9bd35ae2d1183cff5"
+       ],
+       "layout": "IPY_MODEL_08feed14d3f04e6cb0a75f9645f5732c"
+      }
+     },
+     "e91f7981b39449b9a6fd4dcce8692169": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e934546a608941e1a9d389a0db792019": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e941511983404338861b9e8e54ef354a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8608987a16004f0c8fe86bd2c41b4eaa",
+       "max": 9599040,
+       "style": "IPY_MODEL_28814f5e16244e7499996096f46d06ef",
+       "value": 9599040
+      }
+     },
+     "e9465a3b3dc24c47902606e061555881": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e94bc9a8e8254a86a0bcb18dbe0dc232": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_aea3e091813d4b0aad2f1ed163515dbd",
+       "style": "IPY_MODEL_648a9e9ee55246d7878c0b55594bd5b2",
+       "value": " 8.76M/? [00:13&lt;00:00, 3.56MB/s]"
+      }
+     },
+     "e9c262d8cac1430ca8d1f32e4e9e761f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f7547ea0dfc341df8c43c424c52ddcd2",
+       "style": "IPY_MODEL_a64cb8a3267b4845b968b0ebca518272",
+       "value": " 25/25 [00:02&lt;00:00, 11.84file/s]"
+      }
+     },
+     "e9c9c7683cfa4c91a3dc7e5e54f85e11": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5502d0419d424edd968e637490b1f678",
+       "style": "IPY_MODEL_ed9a40be0fa64d8c9183b0277140658a",
+       "value": " 14.8M/? [00:16&lt;00:00, 8.82MB/s]"
+      }
+     },
+     "e9dd13dfa3db45b3a6bf83879c8fe8d1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c7d53bb55bbd4d1884c2cf27022ae775",
+       "style": "IPY_MODEL_ba78679151b240d2aa69bb28c55891be",
+       "value": " 8.86M/? [00:16&lt;00:00, 3.58MB/s]"
+      }
+     },
+     "e9f8e266c0894cdaa1515acb8f4b9bf2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e9fec1f6b5c54359838ec0e5928cb954": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ea0f0d871665451da06ea1443cde404b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ea352ab683694321bd5baafd279a3ecc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ea451995146d4f80a7a74be9653c69be": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ea5064c7178846b8b4dfb6f6fe6ffdff": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ea758de04b2e4d65a72abc73a8c7000d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ea76ca29097a449aacb243b2bc89ce14": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ea9a10abc8f4403a93360c9ccaef2b7b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "eab6ff5a52d649fd8a75e3d66d313c0f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_a17ea92bab2c435bb5254777aeaf2a4d",
+       "max": 48,
+       "style": "IPY_MODEL_8fa521e7798f498686c55e841c049fc3",
+       "value": 48
+      }
+     },
+     "eadd9f3f9356448b9dc8e70bcf191017": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "eafaf8f930fa495f8d5e44a2e9009080": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "eb1b0257b116494597ecb2956b7f3fc4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "eb1b433f47a7422aa94b61971668774e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_48ae6b15da1649ee948d0157676d4a1c",
+        "IPY_MODEL_9836bd35b87c493daa2ff8b56d1a59ce",
+        "IPY_MODEL_f0549e4c35064fbbbb7317ef85cdf5f2"
+       ],
+       "layout": "IPY_MODEL_24a0d338b8bf4127a9bf8332c2ac9b49"
+      }
+     },
+     "eb1df00d01c74662942e96f4fde68146": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_15a247bf8eb14eeeb37d7be75236474f",
+       "max": 9607680,
+       "style": "IPY_MODEL_20fd522bf2b2405e810357a07f2c5720",
+       "value": 9607680
+      }
+     },
+     "eb53ada9cd204d9da78060aac07f3584": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a3811e0f70bb497f9d6f4937f38214ea",
+        "IPY_MODEL_84d9ee028a024181adf1be668e1571b3",
+        "IPY_MODEL_ee61784c44a94ea19fed0fe3a6e9d653"
+       ],
+       "layout": "IPY_MODEL_16eb5a016a90421c9ad584366adc3fc6"
+      }
+     },
+     "eb5cad7a3c5d4f3899d18abde066c028": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "eb6c9815d42a4ef2b7d4bd89e898a89a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bf45f4f28349449ebb39d76412bd28f2",
+       "style": "IPY_MODEL_6ef7b8f082e047b9a4b0014ae8fe0a5f",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.I3.fits: "
+      }
+     },
+     "eb7847a3e25d4245a848be9178198260": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "eba26c13d330498594beb113e88b0bab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_bbd7f92098124c5eb94706cf8ddbbb55",
+       "max": 15560640,
+       "style": "IPY_MODEL_10d20db4d5424ebfa46916342fe94890",
+       "value": 15560640
+      }
+     },
+     "eba750e5359d434e8bc7791194104ef6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ebbde158d326426586a389ac40d4e65c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5b96e01b813242d8a12fe3a0e19b37d3",
+       "style": "IPY_MODEL_3591c05419954712aa387ceafd4e754a",
+       "value": " 9.33M/? [00:14&lt;00:00, 5.88MB/s]"
+      }
+     },
+     "ebc35a8ab35745009de2bcf9f59a8339": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e375c9043c6a414380b44a5cc8b07020",
+       "style": "IPY_MODEL_f56ea93e43124ab3a969976cd6506a5c",
+       "value": "hmi.s_720s.20160729_000000_TAI.3.V3.fits: "
+      }
+     },
+     "ebe5a85ff0e74b0f97f827326faf56e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_629f95ec78be4f2a97e8681ee1efe70b",
+       "style": "IPY_MODEL_8ea98e5d13944bcfbba459be43e77c62",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.U1.fits: "
+      }
+     },
+     "ec2c341999d74ddebfff2c8d658fc763": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ec3e0fcd0eab4cfb8e405d0083146afe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ec42338510e24ad18db649cd98c40620": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ec727f3a74d24f4fa4a4a9c6491d8bfc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_89759427bdf642b5809c5f4a9861ee40",
+        "IPY_MODEL_3e892982da6340fbb64edd4952e97e01",
+        "IPY_MODEL_53ece40b2920459487c06b82181ee11f"
+       ],
+       "layout": "IPY_MODEL_d53f11b9e275432e817e0e98ffb8c5a6"
+      }
+     },
+     "eca18d19b34a4bbea8aa2c4bd8249a5a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ecf112e94c7f474b8c620938a2783c5f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_a34da5ea69f04b47a50821490f7b5f60",
+       "max": 19215360,
+       "style": "IPY_MODEL_630e4d46f7c84acf8fc9f12b4ccd901a",
+       "value": 19215360
+      }
+     },
+     "ed17ab117b1041a68672e56493b0475d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ed1d8dd9b6034bdb9ac8ac36b19054b1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_62eea98c287e4cdd99be8f1f544805c9",
+        "IPY_MODEL_0ddce2d309ea43afafd7733dd948ea61",
+        "IPY_MODEL_70960a6b97d946ddad2a0fc707dc9543"
+       ],
+       "layout": "IPY_MODEL_a172ec9861e14799b4b67127cc2004a2"
+      }
+     },
+     "ed343eee5030454f9416fb699cfc34bc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ed49234b9f4645299b4e180388231941": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d06a94f0600d4841b1bd1041eb33cc05",
+       "style": "IPY_MODEL_de2d3454e05d478db0ffe3dcaa5d8b4a",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.vlos_mag.fits: "
+      }
+     },
+     "ed59d8e5bde94ef093430f3f7d271fa7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8642bdf26b5f4fbfbe6ad55e3469218d",
+       "max": 9550080,
+       "style": "IPY_MODEL_2ffe23975ce740f2b29041bd5c46762e",
+       "value": 9550080
+      }
+     },
+     "ed5bd9a2c2da4cb786586791def2e023": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a822bb2f88fe4f7286d54e460e348643",
+       "style": "IPY_MODEL_a3fbf889643a4697a7e41c94dc0e9712",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V3.fits: "
+      }
+     },
+     "ed608eb7278541f8916c9fc9b95fb588": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f769687fddb5484095ae8d16170fdc2d",
+        "IPY_MODEL_eab6ff5a52d649fd8a75e3d66d313c0f",
+        "IPY_MODEL_8d5e54aa03ef41e2952fc0d739a23601"
+       ],
+       "layout": "IPY_MODEL_9f62e6266d094293935b6dc6aa691162"
+      }
+     },
+     "ed8f63d82c964cab8444ffaf308f40e7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ed9a40be0fa64d8c9183b0277140658a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ed9e5ce696f644c5bad9b4540c792c3f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "edc85c1a6f624cc3af6e90e90d726633": {
+      "model_module": "jupyter-matplotlib",
+      "model_module_version": "^0.9.0",
+      "model_name": "ToolbarModel",
+      "state": {
+       "layout": "IPY_MODEL_921553bca1dd49f6a5a5dd82d3ce43b7",
+       "toolitems": [
+        [
+         "Home",
+         "Reset original view",
+         "home",
+         "home"
+        ],
+        [
+         "Back",
+         "Back to previous view",
+         "arrow-left",
+         "back"
+        ],
+        [
+         "Forward",
+         "Forward to next view",
+         "arrow-right",
+         "forward"
+        ],
+        [
+         "Pan",
+         "Left button pans, Right button zooms\nx/y fixes axis, CTRL fixes aspect",
+         "arrows",
+         "pan"
+        ],
+        [
+         "Zoom",
+         "Zoom to rectangle\nx/y fixes axis, CTRL fixes aspect",
+         "square-o",
+         "zoom"
+        ],
+        [
+         "Download",
+         "Download plot",
+         "floppy-o",
+         "save_figure"
+        ]
+       ]
+      }
+     },
+     "ee1255534b4549c7acbc185586235638": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ee1fba10e4ba4fe1bed24b6407412580": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_fbedca5e9c3c4266a25e6bc6bc1fedf2",
+       "style": "IPY_MODEL_50b1e49e7fb942d18cc3da222aef7605",
+       "value": " 9.61M/? [00:13&lt;00:00, 6.61MB/s]"
+      }
+     },
+     "ee29022186d845bea048f38f671999f1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ee52e67b69b54ffab1840700dae9ddc0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ee5e55cff27442a7b1cd8993d2fe0c25": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ee61784c44a94ea19fed0fe3a6e9d653": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_699a45074bc64149be7c819aca12af86",
+       "style": "IPY_MODEL_41e2a698e0b2468587c1b16e2951258b",
+       "value": " 25/25 [00:02&lt;00:00, 12.59file/s]"
+      }
+     },
+     "ee93c7871253486ba44a98f4a97a0469": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ee95f4ec850844628c951e033bbc5107": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ee98aaf22837408cba6887674aa9ae77": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "eea9dba4f8a2409da8ca72328eabe0b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8c0972ac7ba44dd2a05f2588f9a373af",
+       "max": 14932800,
+       "style": "IPY_MODEL_b350e7ab57c34048a7c9eaa8d20b5899",
+       "value": 14932800
+      }
+     },
+     "eef0f50387084c6c956dc99f5dc3c061": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ef0be8f05ec14209801987d2c7865751": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ef521e85cba94a09aa86d8bdfe480439": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ef57b01acec64e5384a122c62c99b136": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_eef0f50387084c6c956dc99f5dc3c061",
+       "style": "IPY_MODEL_23e8435fc53e44b5a1a4e56a60d12b74",
+       "value": " 14.7M/? [00:19&lt;00:00, 8.44MB/s]"
+      }
+     },
+     "ef6d0cd2293e4e769c90d5eb43dcd9e2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_deef0e5287574dfbbd7226838bca0cc4",
+       "max": 14843520,
+       "style": "IPY_MODEL_cd40d57d576b4c44b2b3bfab3f657fe8",
+       "value": 14843520
+      }
+     },
+     "ef7fa6c609454c1f828e19f3aa4a2747": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_2cbe98c3a3f74da9ad4c6c84702aa80a",
+       "max": 394560,
+       "style": "IPY_MODEL_145eeb97e9634300be6a7a720ada4470",
+       "value": 394560
+      }
+     },
+     "ef8247d0ea414161822972c51d69f1d1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "efe99aeca6af446db72f077ad5b4231f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f0120781641f498ab8d5379462ee3ee9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f0506af07d8446cd869323b797bac3b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f0506b13362e46e7bf733fc42bd569f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f0549e4c35064fbbbb7317ef85cdf5f2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_657c153a22ad4ae1bfdf131c04065d3f",
+       "style": "IPY_MODEL_918f19f9b790464eae2faa75315583c9",
+       "value": " 50/50 [00:04&lt;00:00, 12.15file/s]"
+      }
+     },
+     "f055070b8a1a4f83854c488b99bc7b30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f069330ddd2c442388cb613909dbd727": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f4c7ee6a21de4a5aa9a97dca76bfb407",
+       "style": "IPY_MODEL_2e81efcc1f974ceea26e78622aca7992",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.Q0.fits: "
+      }
+     },
+     "f07962247d15464589f9535c5461f71b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f07e1609b5584c1aae73955c0622d7fe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f097c9954a3b4b8986a4b9053ad51dd0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_cc8b63c6aa6d43108b4bb89c17b7e668",
+        "IPY_MODEL_5a2874adfd7e493e814b46bf519c7b9b",
+        "IPY_MODEL_26c80fa676df428cb3ad2afd012f9a2b"
+       ],
+       "layout": "IPY_MODEL_0510808fecf14cd688aa92166764aa30"
+      }
+     },
+     "f0c60be22c184d6d8efca303aba39067": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6d7dbd1be80249d9ba131adb7b67a539",
+       "style": "IPY_MODEL_6693492dbec74354a39ec646eb826ff9",
+       "value": " 24/24 [01:13&lt;00:00,  3.27s/file]"
+      }
+     },
+     "f10ec793a2454f36b1fb353727a14192": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f15f6559d4354736b4c0512fd4a18518": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_89ccfbaac0564539a35e71dfe302512f",
+       "max": 2897280,
+       "style": "IPY_MODEL_60212ec4dd854799afadcc2796487a46",
+       "value": 2897280
+      }
+     },
+     "f16c14d5ec9047598c147710fb066150": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f170c67c5f674ade8c65ae64f4609b59": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f1b8913fa6c6430fa4870faceaaa9dbc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_9e6dc1b4238645448a472617ec5c2a83",
+       "max": 394560,
+       "style": "IPY_MODEL_79783f393fee44489b748dcaa74f4cac",
+       "value": 394560
+      }
+     },
+     "f1c09988b44043bc8521d63f5a7f5c02": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f228070c0caa437d8cad13b5ae5e73bc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e9f8e266c0894cdaa1515acb8f4b9bf2",
+       "style": "IPY_MODEL_31c3f4d7c2914143b487efee3300e847",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.inclination_alpha_err.fits: "
+      }
+     },
+     "f24aa50463f7400f855f24ebc48c0a1c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f25c126f85fc4c93b7c6152b51aba3f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f2678784c5f8491da11004979aeb795f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a875112e08a44eb2876e698265bde734",
+        "IPY_MODEL_dcc6ad4cecb2453e8130dad079b9cc71",
+        "IPY_MODEL_ee1fba10e4ba4fe1bed24b6407412580"
+       ],
+       "layout": "IPY_MODEL_3f851bb27d2e4bc6a2a4056d1591d8d9"
+      }
+     },
+     "f26aebd79c044794bcab18e7f8fe3c4d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f29f8f127e79402daf3dce0728ac202b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f2ca1e6fae5040428061faef214ab11e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f2d1fede24754fd4921d8dc14444af66": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f31e54bd3ca44efd98890eeda9b213a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f328c6b769d042a9b79cea0ad32dcc10": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f32a803be01a46f6bb9f9e4396f3aa83": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f349ae3a1c394ba6ad1063a8d87e64c8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ee95f4ec850844628c951e033bbc5107",
+       "style": "IPY_MODEL_498e7a9767c7423e8550f1069ff982f8",
+       "value": " 9.60M/? [00:13&lt;00:00, 6.33MB/s]"
+      }
+     },
+     "f3b91e8ac7824abd824ca1fcce035b82": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f3c59c2e351644f9aeab55ea7a7d027b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_282bb61500284e5fb75ce7a6f771d1e2",
+        "IPY_MODEL_0341480858ae4824bd892b5d71b80c84",
+        "IPY_MODEL_265009329b084248a0a8b8dc8b7c4e93"
+       ],
+       "layout": "IPY_MODEL_ee1255534b4549c7acbc185586235638"
+      }
+     },
+     "f3c67c4b5434443bba98cca4f8f77f1e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f3ebbfa3711345e19650a0e78678786c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f3ede3ea67634e32a9fe777df8290271": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_f10ec793a2454f36b1fb353727a14192",
+       "max": 9702720,
+       "style": "IPY_MODEL_fb7334e5ae42436390baa70095157079",
+       "value": 9702720
+      }
+     },
+     "f45f55c1ffd9424393dd429a4f9e387b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_d169a023f32b4c34aef737c594bdc226",
+        "IPY_MODEL_9a7c2230e6ba4695b6ad1bd9edeaf9fe",
+        "IPY_MODEL_c8063c35227f466d805665e51333810f"
+       ],
+       "layout": "IPY_MODEL_418f6f18a57c4376840d689462f1d9d4"
+      }
+     },
+     "f48864750f854b68a06ba213b5e4ade7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b7ba8721b8984766bc4fb2ee2dc81fcd",
+       "style": "IPY_MODEL_49f2d310009a419a85d6bdeb0c540034",
+       "value": " 285k/? [00:11&lt;00:00, 477kB/s]"
+      }
+     },
+     "f49f3ff3ef794b7d9f7ba6e33f585860": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f4c7ee6a21de4a5aa9a97dca76bfb407": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f4e4207b13b949e9a93c073733798777": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f4e80a6f7f6840eea0a584593920e629": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_2fd78e52a2824e73b68b38432116bbc4",
+        "IPY_MODEL_9b6e897b3fca494180b9f653d9474e70",
+        "IPY_MODEL_89bbbfcb03e649d4befb1b375fc64e11"
+       ],
+       "layout": "IPY_MODEL_dd0fb0cfe41944d4909879ca610e8abf"
+      }
+     },
+     "f4f76b7170a6411ab823af9b960c749f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f51b7c74b7be4153be86209d45a36a7f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_98f6ec3882d34f168969cb06a4c81b6d",
+        "IPY_MODEL_a15d2dbf8cd441958f32f2cc92eeb491",
+        "IPY_MODEL_bd03ff7c6be74fd8a1ceece4f6c6740e"
+       ],
+       "layout": "IPY_MODEL_d5c39d7b26084eacb666dd9c71459d8f"
+      }
+     },
+     "f5290fe1b58d4abd9ee3492c780f480c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f529bce1e2834821ba132845bb4d093c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_21352630adeb4ceb8172f195f4eb559a",
+       "style": "IPY_MODEL_05fc4030600046cdaf2f91e409aee81c",
+       "value": " 14.7M/? [00:18&lt;00:00, 6.07MB/s]"
+      }
+     },
+     "f56ea93e43124ab3a969976cd6506a5c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f58186a66e194648865940adf54f3e73": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f5de55cf665d4db9ab37946d838fea58": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f609402455da4dfabf56ec3a54f6f2d3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ea9a10abc8f4403a93360c9ccaef2b7b",
+       "max": 8856000,
+       "style": "IPY_MODEL_e13418fe6a3443dcb41b9a94551a3ac6",
+       "value": 8856000
+      }
+     },
+     "f64cde2118a9484a9e34b05933f93069": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f656f2a9652741adba466c7fd4d4c5f0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f65a94dbd090405b95b463c85e4e4035": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f65c15315a574e3cbcc84ef25ace5700": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f6b888f4ab5246f5af6c61b7e1a673c5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_ebe5a85ff0e74b0f97f827326faf56e1",
+        "IPY_MODEL_9248ccc6277244ae83701c38c4c5e6d5",
+        "IPY_MODEL_6463de8ee03d4e8dbdb5be349b370103"
+       ],
+       "layout": "IPY_MODEL_6746338fda9c4c01b59e4c1623d5ae71"
+      }
+     },
+     "f6eca701e8504d58ac7861f3eea6b53a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f703c8ba10e74d91a744d2260b4d3a8d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f71fb66a9c164e98aeb3a2c832711be9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8c6801fb09bf4e7daa73e1c41c1ee303",
+       "max": 8985600,
+       "style": "IPY_MODEL_4797ac9ecca34ab7af3e7091ef7e6064",
+       "value": 8985600
+      }
+     },
+     "f74d8b9c701a4a05921188c839f77aed": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f7547ea0dfc341df8c43c424c52ddcd2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f75673f3ee574de2a0b47faf7b8b4d41": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1afa4c19bb454153b404b95906bbed0f",
+       "style": "IPY_MODEL_0d0c81a16de249cd9121662ddf13b82a",
+       "value": " 48/48 [00:03&lt;00:00, 12.40file/s]"
+      }
+     },
+     "f769687fddb5484095ae8d16170fdc2d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8a21c6d6586f4b1a9d5d831c068abf30",
+       "style": "IPY_MODEL_3ea999b89e0141b39ab7bdb1e48f9b0b",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "f781e851b59f4e3d9011a56d962f2f81": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f7cca1a3bb714936b72246d12ee17ca2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_54e1e7ce932f4320b51b6d8eb80921e0",
+       "style": "IPY_MODEL_8fb61f080d644168a6096cba608ffe4d",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.qual_map.fits: "
+      }
+     },
+     "f7edb6ac6f3e40a19692e130f19cf44a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f7fd1412592c4e38bd4d09fa54b68de5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f8022c03ebd94e53825ee25d58ad3e9c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f8118f50a9f743ccbff4fde80fde07fa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f83ddc1dc4a1440686a3287ac000dbd0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f8cc32cba30142c7be86a796be005d00": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f9243cb6e2794557904aadd8383d4f75": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f926920e8a074e088913a95d5cc469fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f99b3076084f4fc8b22f4b4c6dbe85eb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f9a3ea3527914121ad1ad0e63c64a38c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fa01512694f64369b5614757cad43f25": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d73e5a733b684ce8b46fa19cfe8a9bfe",
+       "style": "IPY_MODEL_64e1aa77bc2648e994a993d432bc5190",
+       "value": " 9.34M/? [00:14&lt;00:00, 4.10MB/s]"
+      }
+     },
+     "fa3cec6f1a08455e8137c480bd3d67f2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fa6d95dfd7fc451c88ca7df9df62df54": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fa891b81f28a4dd88c387af66f0ec252": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_3f380b099e824632906dda2b8cf99f58",
+       "max": 24,
+       "style": "IPY_MODEL_34abb7e5068f49799e9761252950f59e",
+       "value": 24
+      }
+     },
+     "fa8d7b3c26fa4bb1bdaeed3e0682f195": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "faa550e4276a408b840a440843e9d5a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a82ae1126e084f3c846ee0f06faba2b0",
+       "style": "IPY_MODEL_c9c0e8d2da0a44c689c5dfc4d2c1ae70",
+       "value": " 50/50 [01:22&lt;00:00, 10.34file/s]"
+      }
+     },
+     "faafa999522e4cb3aa2c18fef0b32eaf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fb0b0a62974e4d7889067ac69e20774d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fb1f300b86964dc08ed89e4242f28e45": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fb3798ad7bd941db97aa4f0bf480c753": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fb4706b7156541b4a0c9cdc9a7ba3fa1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fb7334e5ae42436390baa70095157079": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fb886e22433f4c64bf565198d346ccf5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5657143ab2e34d2f915b37da2464af60",
+       "style": "IPY_MODEL_ed8f63d82c964cab8444ffaf308f40e7",
+       "value": "hmi.me_720s_fd10.20160729_000000_TAI.inclination.fits: "
+      }
+     },
+     "fb8e58643df0473cb86239d308fdf645": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_21e12b1a0b52494b9dc948e108f3df7c",
+       "max": 50,
+       "style": "IPY_MODEL_45dc4b42ec454f70a67766f85bc65545",
+       "value": 50
+      }
+     },
+     "fba60fd6486447de9d8981dabcd8f1ed": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e67890dc60b14c3cb57271b8e42f58f6",
+       "style": "IPY_MODEL_287b10958a1b4a17a45989578830b352",
+       "value": " 395k/? [00:19&lt;00:00, 738kB/s]"
+      }
+     },
+     "fbedca5e9c3c4266a25e6bc6bc1fedf2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fbfe79f4218e47f8b154052781ee226a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fc47112281984dad8c5649ffe6adbf28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fc94dd9de7a245b3aa70ca90bc9e6296": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fcb82cc8f87342869f81a30dfa834b88": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fcbb51d7ca3242599596762152b6a5cf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fcc6ce6c346745f49a77febe3f73b4a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fcdd77dbb8eb43e39f5d6d21318ef7df": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fcfb98f2cc9848ad9a6bdba7168568cb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fd05e523c1e04211b91502ccfc6df98b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fd49461117f545e79fbb386ce1c80edf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_251fa70901bb4697aa6f79ead2a199fb",
+       "style": "IPY_MODEL_f74d8b9c701a4a05921188c839f77aed",
+       "value": " 8.86M/? [00:18&lt;00:00, 5.55MB/s]"
+      }
+     },
+     "fd508dfe690c4deb973d685f9fbb03b8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fd61430bef6f48378c32963ac9995215": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_ec2c341999d74ddebfff2c8d658fc763",
+       "max": 9702720,
+       "style": "IPY_MODEL_f49f3ff3ef794b7d9f7ba6e33f585860",
+       "value": 9702720
+      }
+     },
+     "fd6ec000fcdf413cacb15d58b81678b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fdc17c21fa4543e7a0d69008e6e0928f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7880ee4fcac24e8bab260ef437978abd",
+       "style": "IPY_MODEL_014cb3b16da94081b3a23d095b0acbe4",
+       "value": "Files Downloaded: 100%"
+      }
+     },
+     "fe17ab2c0bce4927ba59b7cd0b1a94a5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_722b0429a64e4e13a754f015404d4050",
+       "max": 10411200,
+       "style": "IPY_MODEL_de9a24df05eb4d83ba41212c6ecc1374",
+       "value": 10411200
+      }
+     },
+     "fe292b51dfa14b0f9f05372fada173c7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fe2bcb2317d64ad981608e1c4302d68c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fe33faf6855c4bbabc9893df36dd2a1d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_48a49dcdf7b744cdac00d2784be19e79",
+       "style": "IPY_MODEL_e8e1d80050914499aa4e93067ca20fba",
+       "value": "hmi.me_720s_fd10.20160728_234800_TAI.conv_flag.fits: "
+      }
+     },
+     "fe583b8d61ab4799ae5883fe6b35a600": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fe7cc6d8c88e47ec8da51c47eeeca873": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "feb216d9b5ad4aa291e4068cef8e84d3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_558b67fa6e3d46a999fc5dc9b48623d8",
+       "style": "IPY_MODEL_42bebe24770748898f012b4eaee400b5",
+       "value": " 14.7M/? [00:16&lt;00:00, 8.76MB/s]"
+      }
+     },
+     "febd6604cee143eb99fb4dba4f514ccd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_12243ee759bf4dbab39e1b49e44d9651",
+        "IPY_MODEL_e33a3623015349c796f14de8d498b083",
+        "IPY_MODEL_f349ae3a1c394ba6ad1063a8d87e64c8"
+       ],
+       "layout": "IPY_MODEL_81ef3e4e98b24e098fb22226b56e3489"
+      }
+     },
+     "fec9c70af7e14c2da13d9cac77723890": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fee37904714340cbb5fc45188f95abc3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ff133777a9994f219c80af78feb8b72e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ff16639bf9954cdb914648c47ce83cc2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_79a1144fb1e748a6bafa118c3c9f3504",
+        "IPY_MODEL_a31e3892f4bc4fd08f79d4dccd86be88",
+        "IPY_MODEL_bb0c4a91aeb94cac9136042cf167f59a"
+       ],
+       "layout": "IPY_MODEL_85f5f0f2727d4b3495cd6567b41e8a9b"
+      }
+     },
+     "ff3e2dd8a46f4031a44f5d5ffc531003": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ff622c4642584faa99223fb2199a8390": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ff79837b066848eab884a78d92cf9620": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_af9905050a134fc7a36373586c244e72",
+       "style": "IPY_MODEL_a45f9f6c7dd047eaa660aeefe2ccf7ae",
+       "value": "hmi.s_720s.20160728_234800_TAI.3.V2.fits: "
+      }
+     },
+     "ffa35ae7c8fe4eebb5455250d412ad38": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f228070c0caa437d8cad13b5ae5e73bc",
+        "IPY_MODEL_f1b8913fa6c6430fa4870faceaaa9dbc",
+        "IPY_MODEL_3472fc8f32c54c029e959a9c8d6979f5"
+       ],
+       "layout": "IPY_MODEL_cc792b696bc54232a2f01f1df6c812d0"
+      }
+     },
+     "ffc31fe47ba04302b99569d0b2045e39": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ffef82145b0f4681ac2faf54994695fb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_7b602a1cc2a84614816ba50b2b6804de",
+       "max": 20609280,
+       "style": "IPY_MODEL_21ec717dead0415da2f2b80fe229bf9e",
+       "value": 20609280
+      }
      }
     },
     "version_major": 2,


### PR DESCRIPTION
Fixed the bugs in MagVectorCube but kept the same 3 axes configuration
for the data as before. In the end I could not make sense of adding
an axis for each magnetic field component.

Added a function make_def_wcs that creates a default wcs object.

Fixed the HMI_data_load notebook to include a function that finds
the nearest HMI data series to an input date and downloads it or
searches for it if the files already exist. This creates a folder
either at user specification or by default to store the data. 

However, I modified the .gitignore file to include any default folder that
is named Data/ and it seems to be working.